### PR TITLE
Migrate unit tests for Protocols.Connector project 

### DIFF
--- a/src/libraries/Core/Protocols/Microsoft.Agents.Protocols/Connector/RestUserTokenClient.cs
+++ b/src/libraries/Core/Protocols/Microsoft.Agents.Protocols/Connector/RestUserTokenClient.cs
@@ -12,6 +12,9 @@ using System.Threading.Tasks;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Agents.Protocols.Serializer;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Agents.Connector.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 
 namespace Microsoft.Agents.Protocols.Connector
 {

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/BotSignInRestClientTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/BotSignInRestClientTests.cs
@@ -12,28 +12,28 @@ namespace Microsoft.Agents.Protocols.Connector.Tests
 {
     public class BotSignInRestClientTests
     {
-        private readonly Uri Endpoint = new("http://localhost");
+        private static readonly Uri Endpoint = new("http://localhost");
+        private const string State = "state";
+        private const string CodeCallenge = "code-challenge";
+        private const string EmulatorUrl = "emulator-url";
+        private const string FinalRedirect = "final-redirect";
 
         [Fact]
-        public void BotSignInRestClient_ShouldThrowOnNullBaseUri()
+        public void Constructor_ShouldInstantiateCorrectly()
         {
-            Assert.Throws<UriFormatException>(() =>
-            {
-                var pipeline = CreateHttpPipeline();
-                return new BotSignInRestClient(pipeline, null);
-            });
-        }
-
-        [Fact]
-        public void BotSignInRestClient_ShouldNotThrowOnHttpUrl()
-        {
-            var pipeline = CreateHttpPipeline();
-            var client = new BotSignInRestClient(pipeline, Endpoint);
+            var client = UseClient();
             Assert.NotNull(client);
         }
 
         [Fact]
-        public void BotSignInRestClient_ShouldThrowOnNullHttpPipeline()
+        public void Constructor_ShouldThrowOnNullEndpoint()
+        {
+            var pipeline = CreateHttpPipeline();
+            Assert.Throws<UriFormatException>(() => new BotSignInRestClient(pipeline, null));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullHttpPipeline()
         {
             Assert.Throws<ArgumentNullException>(() => new BotSignInRestClient(null, Endpoint));
         }
@@ -42,38 +42,29 @@ namespace Microsoft.Agents.Protocols.Connector.Tests
         [Fact]
         public async Task GetSignInUrlAsync_ShouldThrowOnNullState()
         {
-            var pipeline = CreateHttpPipeline();
-            var client = new BotSignInRestClient(pipeline, Endpoint);
+            var client = UseClient();
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInUrlAsync(null));
         }
 
         [Fact]
-        public async Task GetSignInUrlAsync_ShouldThrowOnNoLocalBot()
+        public async Task GetSignInUrlAsync_ShouldThrowWithoutLocalBot()
         {
-            var pipeline = CreateHttpPipeline();
-            var client = new BotSignInRestClient(pipeline, Endpoint);
-
-            await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSignInUrlAsync(
-                "dummyState", "dummyCodeChallenge", "dummyEmulatorUrl", "dummyFinalRedirect"));
+            var client = UseClient();
+            await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSignInUrlAsync(State, CodeCallenge, EmulatorUrl, FinalRedirect));
         }
 
         [Fact]
         public async Task GetSignInResourceAsync_ShouldThrowOnNullState()
         {
-            var pipeline = CreateHttpPipeline();
-            var client = new BotSignInRestClient(pipeline, Endpoint);
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInResourceAsync(
-                null, null));
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInResourceAsync(null, null));
         }
 
         [Fact]
-        public async Task GetSignInResourceAsync_ShouldThrowOnNoLocalBot()
+        public async Task GetSignInResourceAsync_ShouldThrowWithoutLocalBot()
         {
-            var pipeline = CreateHttpPipeline();
-            var client = new BotSignInRestClient(pipeline, Endpoint);
-
-            await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSignInResourceAsync(
-                "dummyState", "dummyCodeChallenge", "dummyEmulatorUrl", "dummyFinalRedirect"));
+            var client = UseClient();
+            await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSignInResourceAsync(State, CodeCallenge, EmulatorUrl, FinalRedirect));
         }
 
         private static HttpPipeline CreateHttpPipeline(int maxRetries = 0)
@@ -82,6 +73,11 @@ namespace Microsoft.Agents.Protocols.Connector.Tests
             options.Retry.MaxRetries = maxRetries;
             var pipeline = HttpPipelineBuilder.Build(options, new DefaultHeadersPolicy(options));
             return pipeline;
+        }
+
+        private static BotSignInRestClient UseClient()
+        {
+            return new BotSignInRestClient(CreateHttpPipeline(), Endpoint);
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/BotSignInRestClientTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/BotSignInRestClientTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.Pipeline;
+using Azure;
+using Microsoft.Agents.Protocols.Primitives;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Agents.Protocols.Connector.Tests
+{
+    public class BotSignInRestClientTests
+    {
+        private readonly Uri Endpoint = new("http://localhost");
+
+        [Fact]
+        public void BotSignInRestClient_ShouldThrowOnNullBaseUri()
+        {
+            Assert.Throws<UriFormatException>(() =>
+            {
+                var pipeline = CreateHttpPipeline();
+                return new BotSignInRestClient(pipeline, null);
+            });
+        }
+
+        [Fact]
+        public void BotSignInRestClient_ShouldNotThrowOnHttpUrl()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new BotSignInRestClient(pipeline, Endpoint);
+            Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void BotSignInRestClient_ShouldThrowOnNullHttpPipeline()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BotSignInRestClient(null, Endpoint));
+        }
+
+
+        [Fact]
+        public async Task GetSignInUrlAsync_ShouldThrowOnNullState()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new BotSignInRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInUrlAsync(null));
+        }
+
+        [Fact]
+        public async Task GetSignInUrlAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new BotSignInRestClient(pipeline, Endpoint);
+
+            await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSignInUrlAsync(
+                "dummyState", "dummyCodeChallenge", "dummyEmulatorUrl", "dummyFinalRedirect"));
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsync_ShouldThrowOnNullState()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new BotSignInRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInResourceAsync(
+                null, null));
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new BotSignInRestClient(pipeline, Endpoint);
+
+            await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSignInResourceAsync(
+                "dummyState", "dummyCodeChallenge", "dummyEmulatorUrl", "dummyFinalRedirect"));
+        }
+
+        private static HttpPipeline CreateHttpPipeline(int maxRetries = 0)
+        {
+            var options = new ConnectorClientOptions();
+            options.Retry.MaxRetries = maxRetries;
+            var pipeline = HttpPipelineBuilder.Build(options, new DefaultHeadersPolicy(options));
+            return pipeline;
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/Microsoft.Agents.Connector.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/Microsoft.Agents.Connector.Tests.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="xunit"  />
 		<PackageReference Include="xunit.runner.visualstudio" />
 		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Moq"  />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RestUserTokenClientTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RestUserTokenClientTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Agents.Protocols.Connector.Tests
         public async Task GetAadTokensAsync_ShouldThrowOnNullUserId()
         {
             var client = UseClient();
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(null, ChannelId, ResourceUrls, ChannelId, CancellationToken.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(null, ConnectionName, ResourceUrls, ChannelId, CancellationToken.None));
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RestUserTokenClientTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RestUserTokenClientTests.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Agents.Protocols.Primitives;
+using Xunit;
+using Moq;
+using Microsoft.Agents.Authentication;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.Agents.Protocols.Connector.Tests
+{
+    public class RestUserTokenClientTests
+    {
+        private const string AppId = "test-app-id";
+        private const string Audience = "audience";
+        private const string UserId = "user-id";
+        private const string ConnectionName = "connection-name";
+        private const string ChannelId = "channel-id";
+        private const string MagicCode = "magic-code";
+        private readonly Uri OauthEndpoint = new("https://test.endpoint");
+        private readonly List<string> Scopes = [];
+        private readonly Mock<IAccessTokenProvider> AccessTokenMock = new();
+
+        [Fact]
+        public void ConstructorShouldWork()
+        {
+            Assert.NotNull(new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null));
+        }
+
+        [Fact]
+        public void ConstructorWithNullAppIdShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>(() => new RestUserTokenClient(null, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null));
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncOfDisposedTokenShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncWithNullUserIdShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetUserTokenAsync(null, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncWithNullConnectionNameShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetUserTokenAsync(UserId, null, ChannelId, MagicCode, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsyncOfDisposedTokenShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetSignInResourceAsync(ConnectionName, new Activity(), "final-redirect", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsyncWithNullConnectionNameShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetSignInResourceAsync(null, new Activity(), "final-redirect", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsyncWithNullActivityShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetSignInResourceAsync(ConnectionName, null, "final-redirect", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task SignOutUserAsyncOfDisposedTokenShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.SignOutUserAsync(UserId, ConnectionName, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task SignOutUserAsyncWithNullUserIdShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.SignOutUserAsync(null, ConnectionName, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task SignOutUserAsyncWithNullConnectionNameShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.SignOutUserAsync(UserId, null, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsyncOfDisposedTokenShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetTokenStatusAsync(UserId, ConnectionName, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsyncWithNullUserIdShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetTokenStatusAsync(null, ChannelId, "filter", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsyncWithNullChannelIdShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetTokenStatusAsync(UserId, null, "filter", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsyncOfDisposedTokenShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            string[] resourceUrls = { "https://test.url" };
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetAadTokensAsync(UserId, ConnectionName, resourceUrls, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsyncWithNullUserIdShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            string[] resourceUrls = { "https://test.url" };
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetAadTokensAsync(null, ChannelId, resourceUrls, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsyncWithNullConnectionNameShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            string[] resourceUrls = { "https://test.url" };
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetAadTokensAsync(UserId, null, resourceUrls, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task ExchangeTokenAsyncOfDisposedTokenShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            var tokenExchange = new TokenExchangeRequest();
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.ExchangeTokenAsync(UserId, ConnectionName, ChannelId, tokenExchange, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task ExchangeTokenAsyncWithNullUserIdShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            var tokenExchange = new TokenExchangeRequest();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.ExchangeTokenAsync(null, ChannelId, ChannelId, tokenExchange, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task ExchangeTokenAsyncWithNullConnectionNameShouldThrow()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+
+            var tokenExchange = new TokenExchangeRequest();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.ExchangeTokenAsync(UserId, null, ChannelId, tokenExchange, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public void DisposeOfDisposedTokenShouldReturn()
+        {
+            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
+            userToken.Dispose();
+            userToken.Dispose();
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RestUserTokenClientTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RestUserTokenClientTests.cs
@@ -20,250 +20,170 @@ namespace Microsoft.Agents.Protocols.Connector.Tests
         private const string ConnectionName = "connection-name";
         private const string ChannelId = "channel-id";
         private const string MagicCode = "magic-code";
-        private readonly Uri OauthEndpoint = new("https://test.endpoint");
-        private readonly List<string> Scopes = [];
-        private readonly Mock<IAccessTokenProvider> AccessTokenMock = new();
+        private const string FinalRedirect = "final-redirect";
+        private const string IncludeFilter = "include-filter";
+        private static readonly Uri OauthEndpoint = new("https://test.endpoint");
+        private static readonly List<string> Scopes = [];
+        private readonly string[] ResourceUrls = ["https://test.url"];
+        private static readonly Mock<IAccessTokenProvider> AccessTokenMock = new();
+        private readonly TokenExchangeRequest TokenExchangeRequest = new();
 
         [Fact]
-        public void ConstructorShouldWork()
+        public void Constructor_ShouldInstantiateCorrectly()
         {
-            Assert.NotNull(new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null));
+            var client = UseClient();
+            Assert.NotNull(client);
         }
 
         [Fact]
-        public void ConstructorWithNullAppIdShouldThrow()
+        public void Constructor_ShouldThrowOnNullAppId()
         {
             Assert.Throws<ArgumentNullException>(() => new RestUserTokenClient(null, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null));
         }
 
         [Fact]
-        public async Task GetUserTokenAsyncOfDisposedTokenShouldThrow()
+        public async Task GetUserTokenAsync_ShouldThrowOnDisposed()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            userToken.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
-            });
+            var client = UseClient();
+            client.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetUserTokenAsyncWithNullUserIdShouldThrow()
+        public async Task GetUserTokenAsync_ShouldThrowOnNullUserId()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetUserTokenAsync(null, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetUserTokenAsync(null, ConnectionName, ChannelId, MagicCode, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetUserTokenAsyncWithNullConnectionNameShouldThrow()
+        public async Task GetUserTokenAsync_ShouldThrowOnNullConnectionName()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetUserTokenAsync(UserId, null, ChannelId, MagicCode, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetUserTokenAsync(UserId, null, ChannelId, MagicCode, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetSignInResourceAsyncOfDisposedTokenShouldThrow()
+        public async Task GetSignInResourceAsync_ShouldThrowOnDisposed()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            userToken.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                await userToken.GetSignInResourceAsync(ConnectionName, new Activity(), "final-redirect", CancellationToken.None);
-            });
+            var client = UseClient();
+            client.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.GetSignInResourceAsync(ConnectionName, new Activity(), FinalRedirect, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetSignInResourceAsyncWithNullConnectionNameShouldThrow()
+        public async Task GetSignInResourceAsync_ShouldThrowOnNullConnectionName()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetSignInResourceAsync(null, new Activity(), "final-redirect", CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInResourceAsync(null, new Activity(), FinalRedirect, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetSignInResourceAsyncWithNullActivityShouldThrow()
+        public async Task GetSignInResourceAsync_ShouldThrowOnNullActivity()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetSignInResourceAsync(ConnectionName, null, "final-redirect", CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInResourceAsync(ConnectionName, null, FinalRedirect, CancellationToken.None));
         }
 
         [Fact]
-        public async Task SignOutUserAsyncOfDisposedTokenShouldThrow()
+        public async Task SignOutUserAsync_ShouldThrowOnDisposed()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            userToken.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                await userToken.SignOutUserAsync(UserId, ConnectionName, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            client.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.SignOutUserAsync(UserId, ConnectionName, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task SignOutUserAsyncWithNullUserIdShouldThrow()
+        public async Task SignOutUserAsync_ShouldThrowOnNullUserId()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.SignOutUserAsync(null, ConnectionName, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SignOutUserAsync(null, ConnectionName, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task SignOutUserAsyncWithNullConnectionNameShouldThrow()
+        public async Task SignOutUserAsync_ShouldThrowOnNullConnectionName()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.SignOutUserAsync(UserId, null, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SignOutUserAsync(UserId, null, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetTokenStatusAsyncOfDisposedTokenShouldThrow()
+        public async Task GetTokenStatusAsync_ShouldThrowOnDisposed()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            userToken.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                await userToken.GetTokenStatusAsync(UserId, ConnectionName, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            client.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.GetTokenStatusAsync(UserId, ConnectionName, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetTokenStatusAsyncWithNullUserIdShouldThrow()
+        public async Task GetTokenStatusAsync_ShouldThrowOnNullUserId()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetTokenStatusAsync(null, ChannelId, "filter", CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTokenStatusAsync(null, ChannelId, IncludeFilter, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetTokenStatusAsyncWithNullChannelIdShouldThrow()
+        public async Task GetTokenStatusAsync_ShouldThrowOnNullChannelId()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetTokenStatusAsync(UserId, null, "filter", CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTokenStatusAsync(UserId, null, IncludeFilter, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetAadTokensAsyncOfDisposedTokenShouldThrow()
+        public async Task GetAadTokensAsync_ShouldThrowOnDisposed()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            string[] resourceUrls = { "https://test.url" };
-
-            userToken.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                await userToken.GetAadTokensAsync(UserId, ConnectionName, resourceUrls, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            client.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.GetAadTokensAsync(UserId, ConnectionName, ResourceUrls, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetAadTokensAsyncWithNullUserIdShouldThrow()
+        public async Task GetAadTokensAsync_ShouldThrowOnNullUserId()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            string[] resourceUrls = { "https://test.url" };
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetAadTokensAsync(null, ChannelId, resourceUrls, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(null, ChannelId, ResourceUrls, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task GetAadTokensAsyncWithNullConnectionNameShouldThrow()
+        public async Task GetAadTokensAsync_ShouldThrowOnNullConnectionName()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            string[] resourceUrls = { "https://test.url" };
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.GetAadTokensAsync(UserId, null, resourceUrls, ChannelId, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(UserId, null, ResourceUrls, ChannelId, CancellationToken.None));
         }
 
         [Fact]
-        public async Task ExchangeTokenAsyncOfDisposedTokenShouldThrow()
+        public async Task ExchangeTokenAsync_ShouldThrowOnDisposed()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            var tokenExchange = new TokenExchangeRequest();
-
-            userToken.Dispose();
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                await userToken.ExchangeTokenAsync(UserId, ConnectionName, ChannelId, tokenExchange, CancellationToken.None);
-            });
+            var client = UseClient();
+            client.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.ExchangeTokenAsync(UserId, ConnectionName, ChannelId, TokenExchangeRequest, CancellationToken.None));
         }
 
         [Fact]
-        public async Task ExchangeTokenAsyncWithNullUserIdShouldThrow()
+        public async Task ExchangeTokenAsync_ShouldThrowOnNullUserId()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            var tokenExchange = new TokenExchangeRequest();
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.ExchangeTokenAsync(null, ChannelId, ChannelId, tokenExchange, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.ExchangeTokenAsync(null, ConnectionName, ChannelId, TokenExchangeRequest, CancellationToken.None));
         }
 
         [Fact]
-        public async Task ExchangeTokenAsyncWithNullConnectionNameShouldThrow()
+        public async Task ExchangeTokenAsync_ShouldThrowOnNullConnectionName()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-
-            var tokenExchange = new TokenExchangeRequest();
-
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await userToken.ExchangeTokenAsync(UserId, null, ChannelId, tokenExchange, CancellationToken.None);
-            });
+            var client = UseClient();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.ExchangeTokenAsync(UserId, null, ChannelId, TokenExchangeRequest, CancellationToken.None));
         }
 
         [Fact]
-        public void DisposeOfDisposedTokenShouldReturn()
+        public void Constructor_ShouldDisposeTwiceCorrectly()
         {
-            var userToken = new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
-            userToken.Dispose();
-            userToken.Dispose();
+            var client = UseClient();
+            client.Dispose();
+            client.Dispose();
+        }
+
+        private static RestUserTokenClient UseClient()
+        {
+            return new RestUserTokenClient(AppId, OauthEndpoint, AccessTokenMock.Object, Audience, Scopes, null);
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RetryParamsTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RetryParamsTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Agents.Protocols.Primitives;
+using Xunit;
+
+namespace Microsoft.Agents.Protocols.Connector.Tests
+{
+    public class RetryParamTests
+    {
+        [Fact]
+        public void RetryParams_StopRetryingValidation()
+        {
+            var retryParams = RetryParams.StopRetrying;
+            Assert.False(retryParams.ShouldRetry);
+        }
+
+        [Fact]
+        public void RetryParams_DefaultBackOffShouldRetryOnFirstRetry()
+        {
+            var retryParams = RetryParams.DefaultBackOff(0);
+
+            // If this is the first time we retry, it should retry by default
+            Assert.True(retryParams.ShouldRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(50), retryParams.RetryAfter);
+        }
+
+        [Fact]
+        public void RetryParams_DefaultBackOffShouldNotRetryAfter5Retries()
+        {
+            var retryParams = RetryParams.DefaultBackOff(10);
+            Assert.False(retryParams.ShouldRetry);
+        }
+
+        [Fact]
+        public void RetryParams_DelayOutOfBounds()
+        {
+            var retryParams = new RetryParams(TimeSpan.FromSeconds(11), true);
+
+            // RetryParams should enforce the upper bound on delay time
+            Assert.Equal(TimeSpan.FromSeconds(10), retryParams.RetryAfter);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RetryParamsTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/RetryParamsTests.cs
@@ -10,35 +10,31 @@ namespace Microsoft.Agents.Protocols.Connector.Tests
     public class RetryParamTests
     {
         [Fact]
-        public void RetryParams_StopRetryingValidation()
+        public void Constructor_ShouldStopRetrying()
         {
             var retryParams = RetryParams.StopRetrying;
             Assert.False(retryParams.ShouldRetry);
         }
 
         [Fact]
-        public void RetryParams_DefaultBackOffShouldRetryOnFirstRetry()
+        public void Constructor_ShouldRetryByDefault()
         {
             var retryParams = RetryParams.DefaultBackOff(0);
-
-            // If this is the first time we retry, it should retry by default
             Assert.True(retryParams.ShouldRetry);
             Assert.Equal(TimeSpan.FromMilliseconds(50), retryParams.RetryAfter);
         }
 
         [Fact]
-        public void RetryParams_DefaultBackOffShouldNotRetryAfter5Retries()
+        public void Constructor_ShouldEnforceOnMaxRetries()
         {
             var retryParams = RetryParams.DefaultBackOff(10);
             Assert.False(retryParams.ShouldRetry);
         }
 
         [Fact]
-        public void RetryParams_DelayOutOfBounds()
+        public void Constructor_ShouldEnforceOnMaxDelay()
         {
             var retryParams = new RetryParams(TimeSpan.FromSeconds(11), true);
-
-            // RetryParams should enforce the upper bound on delay time
             Assert.Equal(TimeSpan.FromSeconds(10), retryParams.RetryAfter);
         }
     }

--- a/src/tests/Microsoft.Agents.Protocol.Connector.Tests/UserTokenRestClientTests.cs
+++ b/src/tests/Microsoft.Agents.Protocol.Connector.Tests/UserTokenRestClientTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core.Pipeline;
+using Microsoft.Agents.Protocols.Primitives;
+using Xunit;
+
+namespace Microsoft.Agents.Protocols.Connector.Tests
+{
+
+    public class UserTokenRestClientTests
+    {
+        private readonly Uri Endpoint = new("http://localhost");
+
+        [Fact]
+        public void UserTokenRestClient_ShouldThrowOnNullBaseUri()
+        {
+            Assert.Throws<UriFormatException>(() =>
+            {
+                var pipeline = CreateHttpPipeline();
+                return new UserTokenRestClient(pipeline, null);
+            });
+        }
+
+        [Fact]
+        public void UserTokenRestClient_ShouldNotThrowOnHttpUrl()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void UserTokenRestClient_ShouldThrowOnNullHttpPipeline()
+        {
+            Assert.Throws<ArgumentNullException>(() => new UserTokenRestClient(null, Endpoint));
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_ShouldThrowOnEmptyUserId()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTokenAsync(null, "mockConnection", string.Empty));
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_ShouldThrowOnEmptyConnectionName()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTokenAsync("userid", null, string.Empty));
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
+            {
+                // Automated Windows build does not throw an exception.
+                await client.GetTokenAsync("dummyUserid", "dummyConnectionName", "dummyChannelId", "dummyCode");
+            }
+            else
+            {
+                // MacLinux build and local build exception:
+                await Assert.ThrowsAsync<RequestFailedException>(() => client.GetTokenAsync(
+                    "dummyUserid", "dummyConnectionName", "dummyChannelId", "dummyCode"));
+            }
+        }
+
+        [Fact]
+        public async Task SignOutAsync_ShouldThrowOnEmptyUserId()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SignOutAsync(null, "dummyConnection"));
+        }
+
+        [Fact]
+        public async Task SignOutAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
+            {
+                // Automated Windows build exception:
+                await Assert.ThrowsAsync<ErrorResponseException>(() => client.SignOutAsync(
+                    "dummyUserId", "dummyConnectionName", "dummyChannelId"));
+            }
+            else
+            {
+                // MacLinux build and local build exception:
+                await Assert.ThrowsAsync<RequestFailedException>(() => client.SignOutAsync(
+                    "dummyUserId", "dummyConnectionName", "dummyChannelId"));
+            }
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsync_ShouldThrowOnNullUserId()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTokenStatusAsync(null));
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
+            {
+                // Automated Windows build exception:
+                await Assert.ThrowsAsync<ErrorResponseException>(() => client.GetTokenStatusAsync(
+                    "dummyUserId", "dummyChannelId", "dummyInclude"));
+            }
+            else
+            {
+                // MacLinux build and local build exception:
+                await Assert.ThrowsAsync<RequestFailedException>(() => client.GetTokenStatusAsync(
+                    "dummyUserId", "dummyChannelId", "dummyInclude"));
+            }
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNullUserId()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(null, "connection", new AadResourceUrls() { ResourceUrls = new string[] { "hello" } }));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNullConnectionName()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(
+                "dummyUserId", null, new AadResourceUrls() { ResourceUrls = new string[] { "dummyUrl" } }));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
+            {
+                // Automated Windows build exception:
+                await Assert.ThrowsAsync<ErrorResponseException>(() => client.GetAadTokensAsync(
+                    "dummyUserId", "dummyConnectionName", new AadResourceUrls() { ResourceUrls = new string[] { "dummyUrl" } }, "dummyChannelId"));
+            }
+            else
+            {
+                // MacLinux build and local build exception:
+                await Assert.ThrowsAsync<RequestFailedException>(() => client.GetAadTokensAsync(
+                    "dummyUserId", "dummyConnectionName", new AadResourceUrls() { ResourceUrls = new string[] { "dummyUrl" } }, "dummyChannelId"));
+            }
+        }
+
+        [Fact]
+        public async Task ExchangeAsync_ShouldThrowOnNullUserId()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.ExchangeAsyncAsync(
+                null, "dummyConnectionName", "dummyChannelId", new TokenExchangeRequest()));
+        }
+
+        [Fact]
+        public async Task ExchangeAsync_ShouldThrowOnNullConnectionName()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.ExchangeAsyncAsync(
+                "dummyUserId", null, "dummyChannelId", new TokenExchangeRequest()));
+        }
+
+        [Fact]
+        public async Task ExchangeAsync_ShouldThrowOnNullChannelId()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.ExchangeAsyncAsync(
+                "dummyUserId", "dummyConnectionName", null, new TokenExchangeRequest()));
+        }
+
+        [Fact]
+        public async Task ExchangeAsync_ShouldThrowOnNullExchangeRequest()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.ExchangeAsyncAsync(
+                "dummyUserId", "dummyConnectionName", "dummyChannelId", null));
+        }
+
+        [Fact]
+        public async Task ExchangeAsync_ShouldThrowOnNoLocalBot()
+        {
+            var pipeline = CreateHttpPipeline();
+            var client = new UserTokenRestClient(pipeline, Endpoint);
+
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
+            {
+                // Automated Windows build exception:
+                await client.ExchangeAsyncAsync(
+                    "dummyUserId", "dummyConnectionName", "dummyChannelId", new TokenExchangeRequest());
+                Assert.True(true, "No exception thrown.");
+            }
+            else
+            {
+                // MacLinux build and local build exception:
+                await Assert.ThrowsAsync<RequestFailedException>(() => client.ExchangeAsyncAsync(
+                    "dummyUserId", "dummyConnectionName", "dummyChannelId", new TokenExchangeRequest()));
+            }
+        }
+
+        private static HttpPipeline CreateHttpPipeline(int maxRetries = 0)
+        {
+            var options = new ConnectorClientOptions();
+            options.Retry.MaxRetries = maxRetries;
+            var pipeline = HttpPipelineBuilder.Build(options, new DefaultHeadersPolicy(options));
+            return pipeline;
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR migrates the missing unit tests from _BotBuilder-DotNet_, to cover the _RestUserTokenClient_, _BotSignInRestClient_, _RetryParams_, and _UserTokenRestClient_ classes of **_Microsoft.Agents.Protocols.Connector_** project.

## Detailed Changes
- Added test classes to covert each _RestUserTokenClient_, _BotSignInRestClient_, _RetryParams_, and _UserTokenRestClient_ class.

## Testing
This image shows the new tests passing.
![image](https://github.com/user-attachments/assets/d7a4bd54-28dc-4266-965b-c3366a80b5f9)
