### PR TITLE
Add unit tests for the Microsoft.Agents.Storage namespace

### DIFF
--- a/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/BlobsStorage.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/BlobsStorage.cs
@@ -244,6 +244,8 @@ namespace Microsoft.Agents.Storage.Blobs
         //<inheritdoc/>
         public Task WriteAsync<TStoreItem>(IDictionary<string, TStoreItem> changes, CancellationToken cancellationToken = default) where TStoreItem : class
         {
+            ArgumentNullException.ThrowIfNull(changes);
+
             Dictionary<string, object> changesAsObject = new Dictionary<string, object>(changes.Count);
             foreach (var change in changes)
             {

--- a/src/tests/Microsoft.Agents.Storage.Tests/CosmosDbPartitionedStorageTests.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/CosmosDbPartitionedStorageTests.cs
@@ -12,6 +12,9 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Agents.Storage.CosmosDb;
 using Moq;
 using Xunit;
+using static Microsoft.Agents.Storage.CosmosDb.CosmosDbPartitionedStorage;
+using Microsoft.Agents.Core.Serialization;
+using Microsoft.Agents.BotBuilder.Dialogs;
 
 namespace Microsoft.Agents.Storage.Tests
 {
@@ -110,92 +113,18 @@ namespace Microsoft.Agents.Storage.Tests
             {
                 RealId = "RealId",
                 ETag = "ETag1",
-                Document = (JsonObject)JsonObject.Parse("{ \"ETag\":\"ETag2\" }")
+                Document = JsonObject.Parse("{ \"ETag\":\"ETag2\" }").AsObject()
             };
             var itemResponse = new DocumentStoreItemResponseMock(resource);
 
             _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(itemResponse);
 
-            var items = await _storage.ReadAsync(new string[] { "key" });
+            var items = await _storage.ReadAsync(["key"]);
 
             Assert.Single(items);
             _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
-
-        /*
-        [Fact]
-        public async Task ReadAsyncWithAllowedTypesSerializationBinder()
-        {
-            var jsonSerializerSettings = new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All, // CODEQL [cs/unsafe-type-name-handling] we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
-                MaxDepth = null,
-                SerializationBinder = new AllowedTypesSerializationBinder(
-                    new List<Type>
-                    {
-                        typeof(IStoreItem),
-                    }),
-            };
-
-            InitStorage(jsonSerializerSettings: jsonSerializerSettings);
-            
-            var storeItem = new StoreItem
-            {
-                ETag = "*"
-            };
-            var document = JObject.FromObject(storeItem, JsonSerializer.Create(jsonSerializerSettings));
-            var resource = new CosmosDbPartitionedStorage.DocumentStoreItem
-            {
-                RealId = "RealId",
-                ETag = "ETag1",
-                Document = document
-            };
-            var itemResponse = new DocumentStoreItemResponseMock(resource);
-
-            _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(itemResponse);
-
-            var items = await _storage.ReadAsync(new string[] { "key" });
-
-            Assert.Single(items);
-            _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
-        }
-        */
-
-        /*
-        [Fact]
-        public async Task ReadAsyncWithEmptyAllowedTypesSerializationBinder()
-        {
-            var jsonSerializerSettings = new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All, // CODEQL [cs/unsafe-type-name-handling] we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
-                MaxDepth = null,
-                SerializationBinder = new AllowedTypesSerializationBinder(),
-            };
-            InitStorage(jsonSerializerSettings: jsonSerializerSettings);
-            
-            var storeItem = new StoreItem
-            {
-                ETag = "*"
-            };
-            var document = JObject.FromObject(storeItem, JsonSerializer.Create(jsonSerializerSettings));
-            var resource = new CosmosDbPartitionedStorage.DocumentStoreItem
-            {
-                RealId = "RealId",
-                ETag = "ETag1",
-                Document = document
-            };
-            var itemResponse = new DocumentStoreItemResponseMock(resource);
-
-            _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(itemResponse);
-
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.ReadAsync(new string[] { "key" }));
-
-            _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
-        }
-        */
 
         [Fact]
         public async Task ReadAsyncPartitionKey()
@@ -206,14 +135,14 @@ namespace Microsoft.Agents.Storage.Tests
             {
                 RealId = "RealId",
                 ETag = "ETag1",
-                Document = (JsonObject)JsonObject.Parse("{ \"ETag\":\"ETag2\" }")
+                Document = JsonObject.Parse("{ \"ETag\":\"ETag2\" }").AsObject()
             };
             var itemResponse = new DocumentStoreItemResponseMock(resource);
 
             _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(itemResponse);
 
-            var items = await _storage.ReadAsync(new string[] { "key" });
+            var items = await _storage.ReadAsync(["key"]);
 
             Assert.Single(items);
             _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -227,7 +156,7 @@ namespace Microsoft.Agents.Storage.Tests
             _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new CosmosException("NotFound", HttpStatusCode.NotFound, 0, "0", 0));
 
-            var items = await _storage.ReadAsync(new string[] { "key" });
+            var items = await _storage.ReadAsync(["key"]);
 
             Assert.Empty(items);
             _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -241,7 +170,7 @@ namespace Microsoft.Agents.Storage.Tests
             _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
 
-            await Assert.ThrowsAsync<CosmosException>(() => _storage.ReadAsync(new string[] { "key" }));
+            await Assert.ThrowsAsync<CosmosException>(() => _storage.ReadAsync(["key"]));
             _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -250,7 +179,33 @@ namespace Microsoft.Agents.Storage.Tests
         {
             InitStorage("/customKey");
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.ReadAsync(new string[] { "key" }));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.ReadAsync(["key"]));
+        }
+
+        [Fact]
+        public async Task ReadAsync_ShouldReturnStoreItem()
+        {
+            InitStorage();
+
+            var item = new StoreItem();
+            var document = JsonObject.Parse(JsonSerializer.Serialize(item)).AsObject();
+            document.AddTypeInfo(item);
+
+            var resource = new DocumentStoreItem
+            {
+                RealId = "RealId",
+                ETag = "ETag1",
+                Document = document
+            };
+            var itemResponse = new DocumentStoreItemResponseMock(resource);
+
+            _container.Setup(e => e.ReadItemAsync<DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(itemResponse);
+
+            var items = await _storage.ReadAsync<StoreItem>(["key"]);
+
+            Assert.Single(items);
+            _container.Verify(e => e.ReadItemAsync<DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -283,79 +238,6 @@ namespace Microsoft.Agents.Storage.Tests
 
             _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
         }
-        
-        /*
-        [Fact]
-        public async Task WriteAsyncWithAllowedTypesSerializationBinder()
-        {            
-            var serializationBinder = new AllowedTypesSerializationBinder(
-                new List<Type>
-                {
-                    typeof(IStoreItem),
-                });
-            var jsonSerializerSettings = new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All, // CODEQL [cs/unsafe-type-name-handling] we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
-                MaxDepth = null,
-                SerializationBinder = serializationBinder,
-            };
-
-            InitStorage(jsonSerializerSettings: jsonSerializerSettings);
-
-            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()));
-            
-            var storeItem = new StoreItem
-            {
-                ETag = "*"
-            };
-            var document = JObject.FromObject(storeItem, JsonSerializer.Create(jsonSerializerSettings));
-            var changes = new Dictionary<string, object>
-            {
-                { "key1", new CosmosDbPartitionedStorage.DocumentStoreItem() },
-                { "key2", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = "*", Document = document } },
-                { "key3", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = "ETag" } },
-            };
-
-            await _storage.WriteAsync(changes);
-
-            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
-            Assert.Equal(3, serializationBinder.AllowedTypes.Count);
-        }
-        */
-        
-        /*
-        [Fact]
-        public async Task WriteAsyncWithEmptyAllowedTypesSerializationBinder()
-        {            
-            var serializationBinder = new AllowedTypesSerializationBinder();
-            var jsonSerializerSettings = new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All, // CODEQL [cs/unsafe-type-name-handling] we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
-                MaxDepth = null,
-                SerializationBinder = serializationBinder,
-            };
-            InitStorage(jsonSerializerSettings: jsonSerializerSettings);
-
-            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()));
-            
-            var storeItem = new StoreItem
-            {
-                ETag = "*"
-            };
-            var document = JObject.FromObject(storeItem, JsonSerializer.Create(jsonSerializerSettings));
-            var changes = new Dictionary<string, object>
-            {
-                { "key1", new CosmosDbPartitionedStorage.DocumentStoreItem() },
-                { "key2", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = "*", Document = document } },
-                { "key3", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = "ETag" } },
-            };
-
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(changes));
-
-            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(0));
-            Assert.Empty(serializationBinder.AllowedTypes);
-        }
-        */
 
         [Fact]
         public async Task WriteAsyncEmptyTagFailure()
@@ -384,41 +266,56 @@ namespace Microsoft.Agents.Storage.Tests
             _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        /*
+        [Fact]
+        public async Task WriteAsync_ShouldCallUpsertItemAsync()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.UpsertItemAsync(It.IsAny<DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()));
+
+            var changes = new Dictionary<string, DocumentStoreItem>
+            {
+                { "key1", new DocumentStoreItem() },
+                { "key2", new DocumentStoreItem { ETag = "*" } },
+                { "key3", new DocumentStoreItem { ETag = "ETag" } },
+            };
+
+            await _storage.WriteAsync(changes);
+
+            _container.Verify(e => e.UpsertItemAsync(It.IsAny<DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+
+        [Fact]
+        public async Task WriteAsync_ShouldThrowOnNullStoreItemChanges()
+        {
+            InitStorage();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.WriteAsync<DocumentStoreItem>(null, CancellationToken.None));
+        }
+
         [Fact]
         public async Task WriteAsyncWithNestedFailure()
         {
             InitStorage();
 
-            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
-
             var nestedJson = GenerateNestedDict();
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(nestedJson));
-            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            await Assert.ThrowsAsync<JsonException>(() => _storage.WriteAsync(nestedJson));
         }
-        */
 
-        /*
         [Fact]
         public async Task WriteAsyncWithNestedDialogFailure()
         {
             InitStorage();
 
-            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
-
             var nestedJson = GenerateNestedDict();
 
             var dialogInstance = new DialogInstance { State = nestedJson };
-            var dialogState = new DialogState(new List<DialogInstance> { dialogInstance });
+            var dialogState = new DialogState([dialogInstance]);
             var changes = new Dictionary<string, object> { { "state", dialogState } };
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(changes));
-            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            await Assert.ThrowsAsync<JsonException>(() => _storage.WriteAsync(changes));
         }
-        */
 
         [Fact]
         public async Task DeleteAsyncValidation()
@@ -436,7 +333,7 @@ namespace Microsoft.Agents.Storage.Tests
 
             _container.Setup(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()));
 
-            await _storage.DeleteAsync(new string[] { "key" });
+            await _storage.DeleteAsync(["key"]);
 
             _container.Verify(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -449,7 +346,7 @@ namespace Microsoft.Agents.Storage.Tests
             _container.Setup(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new CosmosException("NotFound", HttpStatusCode.NotFound, 0, "0", 0));
 
-            await _storage.DeleteAsync(new string[] { "key" });
+            await _storage.DeleteAsync(["key"]);
 
             _container.Verify(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -462,7 +359,7 @@ namespace Microsoft.Agents.Storage.Tests
             _container.Setup(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
 
-            await Assert.ThrowsAsync<CosmosException>(() => _storage.DeleteAsync(new string[] { "key" }));
+            await Assert.ThrowsAsync<CosmosException>(() => _storage.DeleteAsync(["key"]));
             _container.Verify(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -490,7 +387,7 @@ namespace Microsoft.Agents.Storage.Tests
             _storage = new CosmosDbPartitionedStorage(client.Object, options, jsonSerializerSettings);
         }
 
-        private Dictionary<string, object> GenerateNestedDict()
+        private static Dictionary<string, object> GenerateNestedDict()
         {
             var nested = new Dictionary<string, object>();
             var current = new Dictionary<string, object>();

--- a/src/tests/Microsoft.Agents.Storage.Tests/FileTranscriptTests.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/FileTranscriptTests.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Agents.Storage.Tests
         }
 
         [Fact]
+        public async Task FileTranscript_LogActivitiesShouldCatchException()
+        {
+            await LogActivitiesShouldCatchException();
+        }
+
+        [Fact]
         public async Task FileTranscript_GetConversationActivities()
         {
             await GetTranscriptActivities();

--- a/src/tests/Microsoft.Agents.Storage.Tests/TestTraceListener.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/TestTraceListener.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Agents.Storage.Tests
+{
+    public class TestTraceListener : TraceListener
+    {
+        private readonly StringBuilder _messages = new StringBuilder();
+
+        public override void Write(string message)
+        {
+            _messages.Append(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            _messages.AppendLine(message);
+        }
+
+        public string GetMessages()
+        {
+            return _messages.ToString();
+        }
+
+        public void Clear()
+        {
+            _messages.Clear();
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Storage.Tests/TraceTranscriptLoggerTests.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/TraceTranscriptLoggerTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Serialization;
+using Microsoft.Agents.Storage.Transcript;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+using Activity = Microsoft.Agents.Core.Models.Activity;
+
+namespace Microsoft.Agents.Storage.Tests
+{
+    public class TraceTranscriptLoggerTests
+    {
+        private readonly Activity _activity = new Activity
+        {
+            Id = "test-id",
+            Type = ActivityTypes.Message,
+            From = new ChannelAccount { Id = "user-id", Name = "user-name", Role = "user-role" },
+            Text = "test-text"
+        };
+
+        [Fact]
+        public void Constructor_ShouldInstantiateCorrectly()
+        {
+            var logger = new TraceTranscriptLogger();
+
+            Assert.NotNull(logger);
+        }
+
+        [Fact]
+        public async Task LogActivityAsync_ShouldFailOnNullActivity()
+        {
+            var logger = new TraceTranscriptLogger();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>  logger.LogActivityAsync(null));
+        }
+
+        [Fact]
+        public async Task LogActivityAsync_ShouldLogJsonWithTraceActivityTrue()
+        {
+            var listener = new TestTraceListener();
+            Trace.Listeners.Add(listener);
+            var logger = new TraceTranscriptLogger(true);
+
+            await logger.LogActivityAsync(_activity);
+
+            string traceOutput = listener.GetMessages();
+            Assert.Contains(ProtocolJsonSerializer.ToJson(_activity), traceOutput);
+
+            Trace.Listeners.Remove(listener);
+        }
+
+        [Fact]
+        public async Task LogActivityAsync_ShouldLogActivityWithTraceActivityFalse()
+        {
+            var listener = new TestTraceListener();
+            Trace.Listeners.Add(listener);
+            var logger = new TraceTranscriptLogger(false);
+
+            await logger.LogActivityAsync(_activity);
+
+            string traceOutput = listener.GetMessages();
+
+            if (Debugger.IsAttached)
+            {
+                Assert.Contains(_activity.Text, traceOutput);
+            }
+            else
+            {
+                Assert.DoesNotContain(_activity.Text, traceOutput);
+            }
+
+            Trace.Listeners.Remove(listener);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Storage.Tests/TranscriptLoggerMiddlewareTests.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/TranscriptLoggerMiddlewareTests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.BotBuilder;
 using Microsoft.Agents.BotBuilder.Testing;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Storage.Transcript;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -42,6 +44,101 @@ namespace Microsoft.Agents.Storage.Tests
                     Assert.Equal(3, activities.Items.Count);
                 })
                 .StartTestAsync();
+        }
+        
+        [Fact]
+        public async Task OnTurnAsync_ShouldExecuteOnUpdateActivityHandler()
+        {
+            var transcriptStore = new MemoryTranscriptStore();
+            var sut = new TranscriptLoggerMiddleware(transcriptStore);
+
+            var conversationId = Guid.NewGuid().ToString();
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(conversationId))
+                .Use(sut);
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var created = new Activity
+                {
+                    Text = "created"
+                };
+                await context.SendActivityAsync(created, cancellationToken: cancellationToken);
+
+                var updated = created.Clone();
+                updated.Text = "updated";
+                await context.UpdateActivityAsync(updated, cancellationToken);
+            })
+            .Send("Start")
+            .AssertReply(async (updated) =>
+            {
+                var activities = await transcriptStore.GetTranscriptActivitiesAsync("test", conversationId);
+
+                Assert.Equal("updated", updated.Text);
+                Assert.Equal(2, activities.Items.Count);
+                Assert.Equal("Start", activities.Items[0].Text);
+                Assert.Equal("updated", activities.Items[1].Text);
+            })
+            .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task OnTurnAsync_ShouldExecuteOnDeleteActivityHandler()
+        {
+            var transcriptStore = new MemoryTranscriptStore();
+            var sut = new TranscriptLoggerMiddleware(transcriptStore);
+
+            var conversationId = Guid.NewGuid().ToString();
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(conversationId))
+                .Use(sut);
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var created = new Activity
+                {
+                    Text = "created"
+                };
+                await context.SendActivityAsync(created, cancellationToken: cancellationToken);
+                await context.DeleteActivityAsync(created.Id, cancellationToken);
+                await context.SendActivityAsync("assert", cancellationToken: cancellationToken);
+            })
+            .Send("Start")
+            .AssertReply(async (activity) =>
+            {
+                var activities = await transcriptStore.GetTranscriptActivitiesAsync("test", conversationId);
+
+                Assert.Equal("assert", activity.Text);
+                Assert.Equal(3, activities.Items.Count);
+                Assert.Equal("Start", activities.Items[0].Text);
+                Assert.Equal(ActivityTypes.MessageDelete, activities.Items[1].Type);
+                Assert.Equal("created", activities.Items[1].Text);
+            })
+            .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task OnTurnAsync_ShouldGenerateActivityId()
+        {
+            var transcriptStore = new MemoryTranscriptStore();
+            var sut = new TranscriptLoggerMiddleware(transcriptStore);
+
+            var conversationId = Guid.NewGuid().ToString();
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(conversationId))
+                .Use(sut);
+
+            var activity = new Activity
+            {
+                ChannelId = "test",
+                Text = "testing",
+                Conversation = new ConversationAccount { Id = conversationId },
+            };
+            var turnContext = new TurnContext(adapter, activity);
+            await sut.OnTurnAsync(turnContext, (_) => Task.CompletedTask, CancellationToken.None);
+
+            var activities = await transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, conversationId);
+
+            Assert.Single(activities.Items);
+            Assert.Equal(activity.Text, activities.Items[0].Text);
+            Assert.NotEqual(activity.Id, activities.Items[0].Id);
         }
     }
 }


### PR DESCRIPTION
## Description

This PR migrates unit tests from BotBuilder-DotNet to cover the classes in **_Microsoft.Agents.Storage_**. Also, it adds some additional tests to cover new methods and code paths.

## Detailed Changes
- **BlobsStorage**:
  - Added a validation in the new _WriteAsync<TStoreItem>_ method to handle possible null parameter changes.
  - Added unit tests for new methods _ReadAsync<TStoreItem>_ and _WriteAsync<TStoreItem>_.
  - Removed commented tests related to _SerializationBinder_ as they applied for newtonsoft in BotBuilder-DotNet.
- **CosmosDbPartitionedStorage**
  - Added unit tests for new methods _ReadAsync<TStoreItem>_ and _WriteAsync<TStoreItem>_.
  - Removed commented tests related to _SerializationBinder_ as they applied for newtonsoft in BotBuilder-DotNet.
- **MemoryStorage**
  - Added unit tests for new methods _ReadAsync<TStoreItem>_ and _WriteAsync<TStoreItem>_.
- **FileTransctiptLogger**
   - Added new test in _FileTranscriptTests_ and _TranscriptBaseTests_
   - Replaced _Newtonsoft.Json_ with _ProtocolJsonSerializer_.
   - Added helper class _TestTraceListener_ to verify traced messages and errors.
- **TraceTranscriptLogger**
   - Added new test class _TraceTranscriptLoggerTests_.
- **TranscriptLoggerMiddleware**
   - Added new tests in _TranscriptLoggerMiddlewareTests_.

## Testing
This image shows the Storage unit tests passing.
![image](https://github.com/user-attachments/assets/fed1c663-0fc0-49aa-8343-7ce435446995)
