### PR TITLE
Add unit tests for the Microsoft.Agents.BotBuilder.Dialogs/Debugging folder

### DIFF
--- a/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder.Dialogs/Debugging/SourceRange.cs
+++ b/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder.Dialogs/Debugging/SourceRange.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 
 namespace Microsoft.Agents.BotBuilder.Dialogs.Debugging
 {

--- a/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/DebugSupportTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/DebugSupportTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.BotBuilder.Dialogs.Debugging;
+using Microsoft.Agents.Core.Interfaces;
+using Microsoft.Agents.Core.Models;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Dialogs.Tests.Debugging
+{
+    public class DebugSupportTests
+    {
+        [Fact]
+        public void SourceMap_ShouldReturnDefaultValue()
+        {
+            Assert.IsType<NullSourceMap>(DebugSupport.SourceMap);
+        }
+
+        [Fact]
+        public void SourceMap_ShouldReturnCustomValue()
+        {
+            var sourceMap = new SourceMap();
+            
+            DebugSupport.SourceMap = sourceMap;
+
+            Assert.Equal(sourceMap, DebugSupport.SourceMap);
+        }
+
+        [Fact]
+        public async Task DebuggerStepAsync_ShouldCallStepAsyncPassingDialog()
+        {
+            var mockDialog = new Mock<Dialog>("testDialog");
+
+            var debugger = new Mock<IDialogDebugger>();
+            debugger.Setup(x => x.StepAsync(It.IsAny<DialogContext>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable(Times.Once);
+
+            var mockContext = new Mock<ITurnContext>();
+            mockContext.Setup(tc => tc.TurnState).Returns([]).Verifiable(Times.Exactly(2));
+            mockContext.Object.TurnState.Add(debugger.Object);
+            
+            var dialogContext = new DialogContext(new DialogSet(), mockContext.Object, new DialogState());
+
+            await dialogContext.DebuggerStepAsync(mockDialog.Object, "more", CancellationToken.None);
+
+            Mock.Verify(debugger, mockContext);
+        }
+
+        [Fact]
+        public async Task DebuggerStepAsync_ShouldCallStepAsyncPassingIRecognizer()
+        {
+            var mockRecognizer = new Mock<IRecognizer>();
+
+            var debugger = new Mock<IDialogDebugger>();
+            debugger.Setup(x => x.StepAsync(It.IsAny<DialogContext>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable(Times.Once);
+
+            var mockContext = new Mock<ITurnContext>();
+            mockContext.Setup(tc => tc.TurnState).Returns([]).Verifiable(Times.Exactly(2));
+            mockContext.Object.TurnState.Add(debugger.Object);
+
+            var dialogContext = new DialogContext(new DialogSet(), mockContext.Object, new DialogState());
+
+            await dialogContext.DebuggerStepAsync(mockRecognizer.Object, "more", CancellationToken.None);
+
+            Mock.Verify(debugger, mockContext);
+        }
+
+        [Fact]
+        public async Task DebuggerStepAsync_ShouldCallStepAsyncPassingRecognizer()
+        {
+            var debugger = new Mock<IDialogDebugger>();
+            debugger.Setup(x => x.StepAsync(It.IsAny<DialogContext>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable(Times.Once);
+
+            var mockContext = new Mock<ITurnContext>();
+            mockContext.Setup(tc => tc.TurnState).Returns([]).Verifiable(Times.Exactly(2));
+            mockContext.Object.TurnState.Add(debugger.Object);
+
+            var dialogContext = new DialogContext(new DialogSet(), mockContext.Object, new DialogState());
+
+            await dialogContext.DebuggerStepAsync(new Recognizer(), "more", CancellationToken.None);
+
+            Mock.Verify(debugger, mockContext);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourceContextTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourceContextTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.BotBuilder.Dialogs.Debugging;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Dialogs.Tests.Debugging
+{
+    public class SourceContextTests
+    {
+        [Fact]
+        public void Constructor_ShouldSetPropertiesWithDefaultValues()
+        {
+            var context = new SourceContext();
+
+            Assert.Empty(context.CallStack);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourceMapTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourceMapTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using Microsoft.Agents.BotBuilder.Dialogs.Debugging;
 using Xunit;
 
-namespace Microsoft.Agents.BotBuilder.Dialogs.Tests
+namespace Microsoft.Agents.BotBuilder.Dialogs.Tests.Debugging
 {
     public class SourceMapTests
     {
@@ -62,6 +62,18 @@ namespace Microsoft.Agents.BotBuilder.Dialogs.Tests
             {
                 Assert.False(sourceMap.TryGetValue(item, out range), "shouldn't find item");
             }
+        }
+
+        [Fact]
+        public void SourceMap_ShouldInitializePropertyWithDefaultValue()
+        {
+            Assert.IsType<SourceMap>(SourceMap.Instance);
+        }
+
+        [Fact]
+        public void NullSourceMap_ShouldInitializePropertyWithDefaultValue()
+        {
+            Assert.IsType<NullSourceMap>(NullSourceMap.Instance);
         }
 
         public class Item

--- a/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourcePointTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourcePointTests.cs
@@ -1,0 +1,89 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using Microsoft.Agents.BotBuilder.Dialogs.Debugging;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Dialogs.Tests.Debugging
+{
+    public class SourcePointTests
+    {
+        private const int LineIndex = 5;
+        private const int CharIndex = 1;
+
+        [Fact]
+        public void Constructor_ShouldSetPropertiesWithProvidedValues()
+        {
+            var sourcePoint = new SourcePoint(LineIndex, CharIndex);
+
+            Assert.Equal(LineIndex, sourcePoint.LineIndex);
+            Assert.Equal(CharIndex, sourcePoint.CharIndex);
+        }
+
+        [Fact]
+        public void ToString_ShouldSetValueCorrectly()
+        {
+            var expectedResult = "5:1";
+
+            var sourcePoint = new SourcePoint(LineIndex, CharIndex);
+
+            var strSource = sourcePoint.ToString();
+
+            Assert.Equal(expectedResult, strSource);
+        }
+
+        [Fact]
+        public void DeepClone_ShouldSetValueCorrectly()
+        {
+            var sourcePoint = new SourcePoint(LineIndex, CharIndex);
+
+            var clonedSource = sourcePoint.DeepClone();
+
+            Assert.Equal(sourcePoint, clonedSource);
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnTrueOnEqualObject()
+        {
+            object other = new SourcePoint(LineIndex, CharIndex);
+
+            var sourcePoint = new SourcePoint(LineIndex, CharIndex);
+
+            Assert.True(sourcePoint.Equals(other));
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnFalseOnDifferentObject()
+        {
+            object other = new SourcePoint(12, 4);
+
+            var sourcePoint = new SourcePoint(LineIndex, CharIndex);
+
+            Assert.False(sourcePoint.Equals(other));
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldReturnSameHashForSameSourcePoint()
+        {
+            var sourcePoint1 = new SourcePoint(LineIndex, CharIndex);
+            var sourcePoint2 = new SourcePoint(LineIndex, CharIndex);
+
+            var hashCode1 = sourcePoint1.GetHashCode();
+            var hashCode2 = sourcePoint2.GetHashCode();
+
+            Assert.Equal(hashCode1, hashCode2);
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldReturnDifferentHashForDifferentSourcePoint()
+        {
+            var sourcePoint1 = new SourcePoint(LineIndex, CharIndex);
+            var sourcePoint2 = new SourcePoint(2, 6);
+
+            var hashCode1 = sourcePoint1.GetHashCode();
+            var hashCode2 = sourcePoint2.GetHashCode();
+
+            Assert.NotEqual(hashCode1, hashCode2);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourceRangeTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Dialogs.Tests/Debugging/SourceRangeTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using Microsoft.Agents.BotBuilder.Dialogs.Debugging;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Dialogs.Tests.Debugging
+{
+    public class SourceRangeTests
+    {
+        private const string Path = "BotBuilder.Dialogs.PromptClass";
+        private const int StartLine = 5;
+        private const int EndLine = 6;
+        private const int StartChar = 1;
+        private const int EndChar = 120;
+        
+        [Fact]
+        public void Constructor_ShouldSetPropertiesWithProvidedValues()
+        {
+            var sourceRange = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            Assert.Equal(Path, sourceRange.Path);
+            Assert.Equal(StartLine, sourceRange.StartPoint.LineIndex);
+            Assert.Equal(StartChar, sourceRange.StartPoint.CharIndex);
+            Assert.Equal(EndLine, sourceRange.EndPoint.LineIndex);
+            Assert.Equal(EndChar, sourceRange.EndPoint.CharIndex);
+        }
+
+        [Fact]
+        public void ToString_ShouldSetValueCorrectly()
+        {
+            var expectedResult = "BotBuilder.Dialogs.PromptClass:5:1->6:120";
+
+            var sourceRange = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            var strSource = sourceRange.ToString();
+
+            Assert.Equal(expectedResult, strSource);
+        }
+
+        [Fact]
+        public void DeepClone_ShouldSetValueCorrectly()
+        {
+            var sourceRange = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            var clonedSource = sourceRange.DeepClone();
+
+            Assert.Equal(sourceRange, clonedSource);
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnTrueOnEqualObject()
+        {
+            object other = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            var sourceRange = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            Assert.True(sourceRange.Equals(other));
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnFalseOnDifferentObject()
+        {
+            object other = new SourceRange(Path+".Method", StartLine, StartChar, EndLine, EndChar);
+
+            var sourceRange = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            Assert.False(sourceRange.Equals(other));
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldReturnSameHashForSameSourceRange()
+        {
+            var sourceRange1 = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+            var sourceRange2 = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+
+            var hashCode1 = sourceRange1.GetHashCode();
+            var hashCode2 = sourceRange2.GetHashCode();
+
+            Assert.Equal(hashCode1, hashCode2);
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldReturnDifferentHashForDifferentSourceRange()
+        {
+            var sourceRange1 = new SourceRange(Path, StartLine, StartChar, EndLine, EndChar);
+            var sourceRange2 = new SourceRange(Path, 1, 1, 2, 6);
+
+            var hashCode1 = sourceRange1.GetHashCode();
+            var hashCode2 = sourceRange2.GetHashCode();
+
+            Assert.NotEqual(hashCode1, hashCode2);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR creates unit tests to increase the code coverage in the classes of **_Microsoft.Agents.BotBuilder.Dialogs/Debugging_**.

## Detailed Changes
- Added new test classes: _DebugSupportTests_, _ConnectionSettingsBaseTests_, _SourcePointTests_, and _SourceRangeTests_ files.
- Moved _SourceMapTests_ inside the Debugging folder and added two new tests to cover missing code lines.
- Removed unnecessary using statement in _SourceRange_ class.


## Testing
The following image shows the current coverage of this folder.
![image](https://github.com/user-attachments/assets/d203999a-12ce-4ccd-a3bb-2737fdff5349)