### PR TITLE
Add unit tests for the Microsoft.Agents.BotBuilder.Teams

### DIFF
--- a/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder/Teams/TeamsSSOTokenExchangeMiddleware.cs
+++ b/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder/Teams/TeamsSSOTokenExchangeMiddleware.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Agents.BotBuilder.Teams
         public TeamsSSOTokenExchangeMiddleware(IStorage storage, string connectionName)
         {
             ArgumentNullException.ThrowIfNull(storage);
-            ArgumentNullException.ThrowIfNull(connectionName);
+            ArgumentNullException.ThrowIfNullOrEmpty(connectionName);
 
             _oAuthConnectionName = connectionName;
             _storage = storage;

--- a/src/libraries/Client/Microsoft.Agents.Connector/RestClients/ConversationsRestClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestClients/ConversationsRestClient.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Agents.Connector.RestClients
                     }
             }
         }
-        internal HttpRequestMessage CreateGetConversationPagedMembersRequest(string conversationId, int? pageSize, string continuationToken)
+        internal HttpRequestMessage CreateGetConversationPagedMembersRequest(string conversationId, int? pageSize, string continuationToken = default)
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
@@ -544,7 +544,7 @@ namespace Microsoft.Agents.Connector.RestClients
         }
 
         /// <inheritdoc/>
-        public async Task<PagedMembersResult> GetConversationPagedMembersAsync(string conversationId, int? pageSize = null, string continuationToken = null, CancellationToken cancellationToken = default)
+        public async Task<PagedMembersResult> GetConversationPagedMembersAsync(string conversationId, int? pageSize = default(int?), string continuationToken = null, CancellationToken cancellationToken = default)
         {
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
 

--- a/src/libraries/Client/Microsoft.Agents.Connector/Teams/RestTeamsOperations.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/Teams/RestTeamsOperations.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Agents.Connector.Teams
 
             // In case of throttling, it will retry the operation with default values (10 retries every 50 milliseconds).
             var result = await RetryAction.RunAsync(
-                task: () => GetResponseAsync<BatchOperationState>("GetOperationState", apiUrl, HttpMethod.Post, customHeaders: customHeaders, cancellationToken: cancellationToken),
+                task: () => GetResponseAsync<BatchOperationState>("GetOperationState", apiUrl, HttpMethod.Get, customHeaders: customHeaders, cancellationToken: cancellationToken),
                 retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
 
             return result;
@@ -288,27 +288,29 @@ namespace Microsoft.Agents.Connector.Teams
 
             try
             {
-                using var httpClient = await GetHttpClientAsync().ConfigureAwait(false);
+                var httpClient = await GetHttpClientAsync().ConfigureAwait(false);
                 using var httpResponse = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 switch ((int)httpResponse.StatusCode)
                 {
                     case 200:
                     case 201:
                     case 202:
+                    case 207:
                         {
-                            if (typeof(T) == typeof(string))
+                            if (httpResponse.Content != null)
                             {
                                 var responseContent = await httpResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                                return ProtocolJsonSerializer.ToObject<T>(responseContent);
-                            }
 
-                            var json = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            if (!string.IsNullOrWhiteSpace(json))
-                            {
-                                return ProtocolJsonSerializer.ToObject<T>(json);
+                                if (!string.IsNullOrEmpty(responseContent))
+                                {
+                                    if (typeof(T) == typeof(string))
+                                    {
+                                        return ProtocolJsonSerializer.ToObject<T>(responseContent);
+                                    }
+                                    return ProtocolJsonSerializer.ToObject<T>(httpResponse.Content.ReadAsStream(cancellationToken));
+                                }
                             }
-
-                            return default(T);
+                            return default;
                         }
                     case 429:
                         {

--- a/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsActivityExtensionsTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsActivityExtensionsTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.BotBuilder.Teams;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Teams.Models;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Tests.Teams
+{
+    public class TeamsActivityExtensionsTests
+    {
+        [Fact]
+        public void TeamsGetSelectedChannelId_ShouldReturnChannelId()
+        {
+            IActivity activity = new Activity { ChannelData = new TeamsChannelData { Settings = new TeamsChannelDataSettings { SelectedChannel = new ChannelInfo("channel123") } } };
+
+            var channelId = activity.TeamsGetSelectedChannelId();
+
+            Assert.Equal("channel123", channelId);
+        }
+
+        [Fact]
+        public void TeamsGetSelectedChannelId_ShouldReturnNullOnNullSettings()
+        {
+            IActivity activity = new Activity { ChannelData = new TeamsChannelData { Settings = null } };
+
+            var channelId = activity.TeamsGetSelectedChannelId();
+
+            Assert.Null(channelId);
+        }
+
+        [Fact]
+        public void TeamsGetMeetingInfo_ShouldReturnMeetingId()
+        {
+            var activity = new Activity { ChannelData = new TeamsChannelData { Meeting = new TeamsMeetingInfo { Id = "meeting123" } } };
+
+            var meetingId = activity.TeamsGetMeetingInfo().Id;
+
+            Assert.Equal("meeting123", meetingId);
+        }
+
+        [Fact]
+        public void TeamsGetChannelId_ShouldReturnChannelId()
+        {
+            IActivity activity = new Activity { ChannelData = new TeamsChannelData { Channel = new ChannelInfo { Id = "channel123" } } };
+
+            var channelId = activity.TeamsGetChannelId();
+
+            Assert.Equal("channel123", channelId);
+        }
+
+        [Fact]
+        public void TeamsGetChannelId_ShouldReturnNullOnNullChannel()
+        {
+            IActivity activity = new Activity { ChannelData = new TeamsChannelData { Channel = null } };
+
+            var channelId = activity.TeamsGetChannelId();
+
+            Assert.Null(channelId);
+        }
+
+        [Fact]
+        public void TeamsGetTeamInfo_ShouldReturnTeamId()
+        {
+            IActivity activity = new Activity { ChannelData = new TeamsChannelData { Team = new TeamInfo { Id = "team1234" } } };
+
+            var teamId = activity.TeamsGetTeamInfo().Id;
+
+            Assert.Equal("team1234", teamId);
+        }
+
+        [Fact]
+        public void TeamsGetTeamInfo_ShouldReturnTeamIdFromTypedActivity()
+        {
+            IMessageActivity activity = new Activity { ChannelData = new TeamsChannelData { Team = new TeamInfo { Id = "team123" } } };
+
+            var teamId = activity.TeamsGetTeamInfo().Id;
+
+            Assert.Equal("team123", teamId);
+        }
+
+        [Fact]
+        public void TeamsNotifyUser_ShouldConfigureAlert()
+        {
+            var activity = new Activity { };
+
+            activity.TeamsNotifyUser();
+
+            Assert.Equal(true, ((TeamsChannelData)activity.ChannelData).Notification.Alert);
+            Assert.Equal(false, ((TeamsChannelData)activity.ChannelData).Notification.AlertInMeeting);
+        }
+
+        [Fact]
+        public void TeamsNotifyUser_ShouldConfigureAlertInMeeting()
+        {
+            var activity = new Activity { };
+
+            activity.TeamsNotifyUser(alertInMeeting: true);
+
+            Assert.Equal(true, ((TeamsChannelData)activity.ChannelData).Notification.AlertInMeeting);
+            Assert.Equal(false, ((TeamsChannelData)activity.ChannelData).Notification.Alert);
+        }
+
+        [Fact]
+        public void TeamsNotifyUser_ShouldUseExternalResourceUrl()
+        {
+            string resourceUrl = "https://microsoft.com";
+
+            var activity = new Activity { };
+
+            activity.TeamsNotifyUser(false, externalResourceUrl: resourceUrl);
+
+            Assert.Equal(resourceUrl, ((TeamsChannelData)activity.ChannelData).Notification.ExternalResourceUrl);
+        }
+
+        [Fact]
+        public void TeamsNotifyUser_ShouldNotOverrideExistingChannelData()
+        {
+            var activity = new Activity { ChannelData = new TeamsChannelData { Team = new TeamInfo { Id = "team123" } } };
+
+            activity.TeamsNotifyUser();
+
+            Assert.True(((TeamsChannelData)activity.ChannelData).Notification.Alert);
+            Assert.Equal("team123", ((TeamsChannelData)activity.ChannelData).Team.Id);
+        }
+
+        [Fact]
+        public void TeamsGetTeamOnBehalfOf_ShouldReturnOnBehalfOf()
+        {
+            var onBehalfOf = new OnBehalfOf
+            {
+                DisplayName = "TestOnBehalfOf",
+                ItemId = 0,
+                MentionType = "person",
+                Mri = Guid.NewGuid().ToString()
+            };
+
+            IActivity activity = new Activity { ChannelData = new TeamsChannelData(onBehalfOf: new List<OnBehalfOf> { onBehalfOf }) };
+
+            var onBehalfOfList = activity.TeamsGetTeamOnBehalfOf();
+
+            Assert.Single(onBehalfOfList);
+            Assert.Equal("TestOnBehalfOf", onBehalfOfList[0].DisplayName);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -9,11 +9,18 @@ using Xunit;
 using Microsoft.Agents.Core.Teams.Models;
 using System;
 using System.Globalization;
+using System.Net.Http;
+using System.Threading;
+using System.Net;
+using Microsoft.Agents.Connector.Teams;
+using Microsoft.Agents.Connector;
+using Moq;
 
 namespace Microsoft.Agents.BotBuilder.Tests.Teams
 {
     public class TeamsActivityHandlerTests
     {
+        private const string BaseUri = "https://test.coffee";
         IActivity[] _activitiesToSend = null;
 
         public TeamsActivityHandlerTests()
@@ -61,1536 +68,1415 @@ namespace Microsoft.Agents.BotBuilder.Tests.Teams
             Assert.Equal("OnTeamsMembersAddedAsync", bot.Record[1]);
         }
 
-        //[Fact]
-        //public async Task TestConversationUpdateTeamsMemberAdded()
-        //{
-        //    // Arrange
-        //    var baseUri = new Uri("https://test.coffee");
-        //    var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
-
-        //    // Set a special base address so then we can make sure the connector client is honoring this http client
-        //    customHttpClient.BaseAddress = baseUri;
-        //    var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
-
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.ConversationUpdate,
-        //        MembersAdded = new List<ChannelAccount>
-        //        {
-        //            new ChannelAccount { Id = "id-1" },
-        //        },
-        //        Recipient = new ChannelAccount { Id = "b" },
-        //        ChannelData = new TeamsChannelData
-        //        {
-        //            EventType = "teamMemberAdded",
-        //            Team = new TeamInfo
-        //            {
-        //                Id = "team-id",
-        //            },
-        //        },
-        //        ChannelId = Channels.Msteams,
-        //    };
-
-        //    var turnContext = new TurnContext(new SimpleAdapter(), activity);
-        //    turnContext.TurnState.Add<IConnectorClient>(connectorClient);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMembersAddedAsync", bot.Record[1]);
-        //}
-
-        //[Fact]
-        //public async Task TestConversationUpdateTeamsMemberAddedNoTeam()
-        //{
-        //    // Arrange
-        //    var baseUri = new Uri("https://test.coffee");
-        //    var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
-
-        //    // Set a special base address so then we can make sure the connector client is honoring this http client
-        //    customHttpClient.BaseAddress = baseUri;
-        //    var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
-
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.ConversationUpdate,
-        //        MembersAdded = new List<ChannelAccount>
-        //        {
-        //            new ChannelAccount { Id = "id-1" },
-        //        },
-        //        Recipient = new ChannelAccount { Id = "b" },
-        //        Conversation = new ConversationAccount { Id = "conversation-id" },
-        //        ChannelId = Channels.Msteams,
-        //    };
-
-        //    var turnContext = new TurnContext(new SimpleAdapter(), activity);
-        //    turnContext.TurnState.Add<IConnectorClient>(connectorClient);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMembersAddedAsync", bot.Record[1]);
-        //}
-
-        //[Fact]
-        //public async Task TestConversationUpdateTeamsMemberAddedFullDetailsInEvent()
-        //{
-        //    // Arrange
-        //    var baseUri = new Uri("https://test.coffee");
-        //    var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
-
-        //    // Set a special base address so then we can make sure the connector client is honoring this http client
-        //    customHttpClient.BaseAddress = baseUri;
-        //    var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
-
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.ConversationUpdate,
-        //        MembersAdded = new List<ChannelAccount>
-        //        {
-        //            new TeamsChannelAccount
-        //            {
-        //                Id = "id-1",
-        //                Name = "name-1",
-        //                AadObjectId = "aadobject-1",
-        //                Email = "test@microsoft.com",
-        //                GivenName = "given-1",
-        //                Surname = "surname-1",
-        //                UserPrincipalName = "t@microsoft.com",
-        //            },
-        //        },
-        //        Recipient = new ChannelAccount { Id = "b" },
-        //        ChannelData = new TeamsChannelData
-        //        {
-        //            EventType = "teamMemberAdded",
-        //            Team = new TeamInfo
-        //            {
-        //                Id = "team-id",
-        //            },
-        //        },
-        //        ChannelId = Channels.Msteams,
-        //    };
-
-        //    // code taken from connector - i.e. the send or serialize side
-        //    var serializationSettings = new JsonSerializerSettings();
-        //    serializationSettings.ContractResolver = new DefaultContractResolver();
-        //    var json = Rest.Serialization.SafeJsonConvert.SerializeObject(activity, serializationSettings);
-
-        //    // code taken from integration layer - i.e. the receive or deserialize side
-        //    var botMessageSerializer = JsonSerializer.Create(new JsonSerializerSettings
-        //    {
-        //        NullValueHandling = NullValueHandling.Ignore,
-        //        Formatting = Formatting.Indented,
-        //        DateFormatHandling = DateFormatHandling.IsoDateFormat,
-        //        DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-        //        ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-        //        ContractResolver = new ReadOnlyJsonContractResolver(),
-        //        Converters = new List<JsonConverter> { new Iso8601TimeSpanConverter() },
-        //    });
-
-        //    using (var bodyReader = new JsonTextReader(new StringReader(json)))
-        //    {
-        //        activity = botMessageSerializer.Deserialize<Activity>(bodyReader);
-        //    }
-
-        //    var turnContext = new TurnContext(new SimpleAdapter(), activity);
-        //    turnContext.TurnState.Add<IConnectorClient>(connectorClient);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMembersAddedAsync", bot.Record[1]);
-        //}
-
         [Fact]
-        public async Task TestConversationUpdateTeamsMemberRemoved()
+        public async Task TestConversationUpdateTeamsMemberAddedNoTeam()
         {
-            // Arrange
+            // Arrange 
+            var customHttpClient = new HttpClient(new RosterHttpMessageHandler())
+            {
+                // Set a special base address so then we can make sure the connector client is honoring this http client.
+                BaseAddress = new Uri(BaseUri)
+            };
+
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory.Setup(a => a.CreateClient(It.IsAny<string>()))
+                .Returns(customHttpClient);
+
+            var connectorClient = new RestTeamsConnectorClient(new Uri("http://localhost/"), httpFactory.Object, null);
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersRemoved =
+                MembersAdded =
                 [
-                    new ChannelAccount { Id = "a" },
+                    new ChannelAccount { Id = "id-1" },
                 ],
                 Recipient = new ChannelAccount { Id = "b" },
-                ChannelData = new TeamsChannelData { EventType = "teamMemberRemoved" },
+                Conversation = new ConversationAccount { Id = "conversation-id" },
                 ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMembersRemovedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsChannelCreated()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "channelCreated" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsChannelCreatedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsChannelDeleted()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "channelDeleted" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsChannelDeletedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsChannelRenamed()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "channelRenamed" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsChannelRenamedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsChannelRestored()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "channelRestored" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsChannelRestoredAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsTeamArchived()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "teamArchived" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTeamArchivedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsTeamDeleted()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "teamDeleted" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTeamDeletedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsTeamHardDeleted()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "teamHardDeleted" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTeamHardDeletedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsTeamRenamed()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "teamRenamed" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTeamRenamedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsTeamRestored()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "teamRestored" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTeamRestoredAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestConversationUpdateTeamsTeamUnarchived()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.ConversationUpdate,
-                ChannelData = new TeamsChannelData { EventType = "teamUnarchived" },
-                ChannelId = Channels.Msteams,
-            };
-            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTeamUnarchivedAsync", bot.Record[1]);
-        }
-
-        [Fact]
-        public async Task TestFileConsentAccept()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "fileConsent/invoke",
-                Value = JsonSerializer.SerializeToElement(new FileConsentCardResponse
-                {
-                    Action = "accept",
-                    UploadInfo = new FileUploadInfo
-                    {
-                        UniqueId = "uniqueId",
-                        FileType = "fileType",
-                        UploadUrl = "uploadUrl",
-                    },
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(3, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsFileConsentAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsFileConsentAcceptAsync", bot.Record[2]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestFileConsentDecline()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "fileConsent/invoke",
-                Value = JsonSerializer.SerializeToElement(new FileConsentCardResponse
-                {
-                    Action = "decline",
-                    UploadInfo = new FileUploadInfo
-                    {
-                        UniqueId = "uniqueId",
-                        FileType = "fileType",
-                        UploadUrl = "uploadUrl",
-                    },
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(3, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsFileConsentAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsFileConsentDeclineAsync", bot.Record[2]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestActionableMessageExecuteAction()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "actionableMessage/executeAction",
-                Value = JsonSerializer.SerializeToElement(new O365ConnectorCardActionQuery()),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsO365ConnectorCardActionAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestComposeExtensionQueryLink()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/queryLink",
-                Value = JsonSerializer.SerializeToElement(new AppBasedLinkQuery()),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsAppBasedLinkQueryAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestComposeExtensionAnonymousQueryLink()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/anonymousQueryLink",
-                Value = JsonSerializer.SerializeToElement(new AppBasedLinkQuery()),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsAnonymousAppBasedLinkQueryAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestComposeExtensionQuery()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/query",
-                Value = JsonSerializer.SerializeToElement(new MessagingExtensionQuery()),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionQueryAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionSelectItemAsync()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/selectItem",
-                Value = new JsonElement(),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionSelectItemAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionSubmitAction()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/submitAction",
-                Value = JsonSerializer.SerializeToElement(new MessagingExtensionQuery()),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(3, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensionSubmitActionAsync", bot.Record[2]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionSubmitActionPreviewActionEdit()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/submitAction",
-                Value = JsonSerializer.SerializeToElement(new MessagingExtensionAction
-                {
-                    BotMessagePreviewAction = "edit",
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(3, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensionBotMessagePreviewEditAsync", bot.Record[2]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionSubmitActionPreviewActionSend()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/submitAction",
-                Value = JsonSerializer.SerializeToElement(new MessagingExtensionAction
-                {
-                    BotMessagePreviewAction = "send",
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(3, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensionBotMessagePreviewSendAsync", bot.Record[2]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionFetchTask()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/fetchTask",
-                Value = JsonSerializer.SerializeToElement(new { commandId = "testCommand" }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionFetchTaskAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionConfigurationQuerySettingUrl()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/querySettingUrl",
-                Value = JsonSerializer.SerializeToElement(new { commandId = "testCommand" }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionConfigurationQuerySettingUrlAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessagingExtensionConfigurationSetting()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/setting",
-                Value = JsonSerializer.SerializeToElement(new { commandId = "testCommand" }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMessagingExtensionConfigurationSettingAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestTaskModuleFetch()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "task/fetch",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    data = new
-                    {
-                        key = "value",
-                        type = "task / fetch",
-                    },
-                    context = new
-                    {
-                        theme = "default"
-                    }
-                }),
-                //Value = JObject.Parse(@"{""data"":{""key"":""value"",""type"":""task / fetch""},""context"":{""theme"":""default""}}"),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTaskModuleFetchAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestTaskModuleSubmit()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "task/submit",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    data = new
-                    {
-                        key = "value",
-                        type = "task / fetch",
-                    },
-                    context = new
-                    {
-                        theme = "default"
-                    }
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTaskModuleSubmitAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestTabFetch()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "tab/fetch",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    data = new
-                    {
-                        key = "value",
-                        type = "task / fetch",
-                    },
-                    context = new
-                    {
-                        theme = "default"
-                    }
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTabFetchAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestTabSubmit()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "tab/submit",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    data = new
-                    {
-                        key = "value",
-                        type = "tab / submit",
-                    },
-                    context = new
-                    {
-                        theme = "default"
-                    }
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsTabSubmitAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestConfigFetch()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "config/fetch",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    data = new
-                    {
-                        key = "value",
-                        type = "config / fetch",
-                    },
-                    context = new
-                    {
-                        theme = "default"
-                    }
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsConfigFetchAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestConfigSubmit()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "config/submit",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    data = new
-                    {
-                        key = "value",
-                        type = "config / submit",
-                    },
-                    context = new
-                    {
-                        theme = "default"
-                    }
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsConfigSubmitAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestSigninVerifyState()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "signin/verifyState",
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsSigninVerifyStateAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestOnEventActivity()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                ChannelId = Channels.Directline,
-                Type = ActivityTypes.Event
             };
 
             var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(connectorClient);
 
             // Act
             var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Single(bot.Record);
-            Assert.Equal("OnEventActivityAsync", bot.Record[0]);
-        }
-
-        [Fact]
-        public async Task TestMeetingStartEvent()
-        {
-            // Arrange
-            var startTimeBase = new DateTime(2024, 6, 5, 0, 1, 2);
-            var activity = new Activity
-            {
-                ChannelId = Channels.Msteams,
-                Type = ActivityTypes.Event,
-                Name = "application/vnd.microsoft.meetingStart",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    StartTime = startTimeBase.ToString("o", CultureInfo.InvariantCulture) // "2025-06-05T00:01:02.0Z"
-                }),
-            };
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
+            await ((IBot)bot).OnTurnAsync(turnContext);
 
             // Assert
             Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnEventActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMeetingStartAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.Contains(startTimeBase.ToString(CultureInfo.InvariantCulture), _activitiesToSend[0].Text); // Date format differs between OSs, so we just Assert.Contains instead of Assert.Equals
+            Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+            Assert.Equal("OnTeamsMembersAddedAsync", bot.Record[1]);
         }
 
-        [Fact]
-        public async Task TestMeetingEndEvent()
-        {
-            // Arrange
-            var endTimeBase = new DateTime(2024, 6, 5, 0, 1, 2);
-            var activity = new Activity
+            [Fact]
+            public async Task TestConversationUpdateTeamsMemberAddedFullDetailsInEvent()
             {
-                ChannelId = Channels.Msteams,
-                Type = ActivityTypes.Event,
-                Name = "application/vnd.microsoft.meetingEnd",
-                Value = JsonSerializer.SerializeToElement(new
-                {
-                    EndTime = endTimeBase.ToString("o", CultureInfo.InvariantCulture) //"2021-06-05T01:02:03.0Z"
-                }),
+            var customHttpClient = new HttpClient(new RosterHttpMessageHandler())
+            {
+                // Set a special base address so then we can make sure the connector client is honoring this http client.
+                BaseAddress = new Uri(BaseUri)
             };
 
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+            var httpFactory = new Mock<IHttpClientFactory>();
+                httpFactory.Setup(a => a.CreateClient(It.IsAny<string>()))
+                    .Returns(customHttpClient);
 
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnEventActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsMeetingEndAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.Contains(endTimeBase.ToString(CultureInfo.InvariantCulture), _activitiesToSend[0].Text); // Date format differs between OSs, so we just Assert.Contains instead of Assert.Equals
-        }
-
-        [Fact]
-        public async Task TeamsReadReceiptEvent()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                ChannelId = Channels.Msteams,
-                Type = ActivityTypes.Event,
-                Name = "application/vnd.microsoft.readReceipt",
-                Value = JsonSerializer.SerializeToElement(new
+                var connectorClient = new RestTeamsConnectorClient(new Uri("http://localhost/"), httpFactory.Object, null);
+                
+                var activity = new Activity
                 {
-                    lastReadMessageId = "10101010"
-                }),
-            };
+                    Type = ActivityTypes.ConversationUpdate,
+                    MembersAdded =
+                [
+                    new TeamsChannelAccount
+                    {
+                        Id = "id-1",
+                        Name = "name-1",
+                        AadObjectId = "aadobject-1",
+                        Email = "test@microsoft.com",
+                        GivenName = "given-1",
+                        Surname = "surname-1",
+                        UserPrincipalName = "t@microsoft.com",
+                    },
+                ],
+                    Recipient = new ChannelAccount { Id = "b" },
+                    ChannelData = new TeamsChannelData
+                    {
+                        EventType = "teamMemberAdded",
+                        Team = new TeamInfo
+                        {
+                            Id = "team-id",
+                        },
+                    },
+                    ChannelId = Channels.Msteams,
+                };
 
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+                var turnContext = new TurnContext(new SimpleAdapter(), activity);
+                turnContext.TurnState.Add<IConnectorClient>(connectorClient);
 
-            // Act
-            var bot = new TestActivityHandler();
-            await bot.OnTurnAsync(turnContext);
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
 
-            // Assert
-            Assert.Equal(2, bot.Record.Count);
-            Assert.Equal("OnEventActivityAsync", bot.Record[0]);
-            Assert.Equal("OnTeamsReadReceiptAsync", bot.Record[1]);
-            Assert.NotNull(_activitiesToSend);
-            Assert.Single(_activitiesToSend);
-            Assert.Equal("10101010", _activitiesToSend[0].Text);
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMembersAddedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsMemberRemoved()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    MembersRemoved =
+                    [
+                        new ChannelAccount { Id = "a" },
+                ],
+                    Recipient = new ChannelAccount { Id = "b" },
+                    ChannelData = new TeamsChannelData { EventType = "teamMemberRemoved" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMembersRemovedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsChannelCreated()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "channelCreated" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsChannelCreatedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsChannelDeleted()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "channelDeleted" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsChannelDeletedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsChannelRenamed()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "channelRenamed" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsChannelRenamedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsChannelRestored()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "channelRestored" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsChannelRestoredAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsTeamArchived()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "teamArchived" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTeamArchivedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsTeamDeleted()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "teamDeleted" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTeamDeletedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsTeamHardDeleted()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "teamHardDeleted" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTeamHardDeletedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsTeamRenamed()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "teamRenamed" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTeamRenamedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsTeamRestored()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "teamRestored" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTeamRestoredAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestConversationUpdateTeamsTeamUnarchived()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "teamUnarchived" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTeamUnarchivedAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestFileConsentAccept()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "fileConsent/invoke",
+                    Value = JsonSerializer.SerializeToElement(new FileConsentCardResponse
+                    {
+                        Action = "accept",
+                        UploadInfo = new FileUploadInfo
+                        {
+                            UniqueId = "uniqueId",
+                            FileType = "fileType",
+                            UploadUrl = "uploadUrl",
+                        },
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(3, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsFileConsentAsync", bot.Record[1]);
+                Assert.Equal("OnTeamsFileConsentAcceptAsync", bot.Record[2]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestFileConsentDecline()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "fileConsent/invoke",
+                    Value = JsonSerializer.SerializeToElement(new FileConsentCardResponse
+                    {
+                        Action = "decline",
+                        UploadInfo = new FileUploadInfo
+                        {
+                            UniqueId = "uniqueId",
+                            FileType = "fileType",
+                            UploadUrl = "uploadUrl",
+                        },
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(3, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsFileConsentAsync", bot.Record[1]);
+                Assert.Equal("OnTeamsFileConsentDeclineAsync", bot.Record[2]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestActionableMessageExecuteAction()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "actionableMessage/executeAction",
+                    Value = JsonSerializer.SerializeToElement(new O365ConnectorCardActionQuery()),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsO365ConnectorCardActionAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestComposeExtensionQueryLink()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/queryLink",
+                    Value = JsonSerializer.SerializeToElement(new AppBasedLinkQuery()),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsAppBasedLinkQueryAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestComposeExtensionAnonymousQueryLink()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/anonymousQueryLink",
+                    Value = JsonSerializer.SerializeToElement(new AppBasedLinkQuery()),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsAnonymousAppBasedLinkQueryAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestComposeExtensionQuery()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/query",
+                    Value = JsonSerializer.SerializeToElement(new MessagingExtensionQuery()),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionQueryAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionSelectItemAsync()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/selectItem",
+                    Value = new JsonElement(),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionSelectItemAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionSubmitAction()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/submitAction",
+                    Value = JsonSerializer.SerializeToElement(new MessagingExtensionQuery()),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(3, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
+                Assert.Equal("OnTeamsMessagingExtensionSubmitActionAsync", bot.Record[2]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionSubmitActionPreviewActionEdit()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/submitAction",
+                    Value = JsonSerializer.SerializeToElement(new MessagingExtensionAction
+                    {
+                        BotMessagePreviewAction = "edit",
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(3, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
+                Assert.Equal("OnTeamsMessagingExtensionBotMessagePreviewEditAsync", bot.Record[2]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionSubmitActionPreviewActionSend()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/submitAction",
+                    Value = JsonSerializer.SerializeToElement(new MessagingExtensionAction
+                    {
+                        BotMessagePreviewAction = "send",
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(3, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
+                Assert.Equal("OnTeamsMessagingExtensionBotMessagePreviewSendAsync", bot.Record[2]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionFetchTask()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/fetchTask",
+                    Value = JsonSerializer.SerializeToElement(new { commandId = "testCommand" }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionFetchTaskAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionConfigurationQuerySettingUrl()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/querySettingUrl",
+                    Value = JsonSerializer.SerializeToElement(new { commandId = "testCommand" }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionConfigurationQuerySettingUrlAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestMessagingExtensionConfigurationSetting()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "composeExtension/setting",
+                    Value = JsonSerializer.SerializeToElement(new { commandId = "testCommand" }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessagingExtensionConfigurationSettingAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestTaskModuleFetch()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "task/fetch",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        data = new
+                        {
+                            key = "value",
+                            type = "task / fetch",
+                        },
+                        context = new
+                        {
+                            theme = "default"
+                        }
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTaskModuleFetchAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestTaskModuleSubmit()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "task/submit",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        data = new
+                        {
+                            key = "value",
+                            type = "task / fetch",
+                        },
+                        context = new
+                        {
+                            theme = "default"
+                        }
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTaskModuleSubmitAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestTabFetch()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "tab/fetch",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        data = new
+                        {
+                            key = "value",
+                            type = "task / fetch",
+                        },
+                        context = new
+                        {
+                            theme = "default"
+                        }
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTabFetchAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestTabSubmit()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "tab/submit",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        data = new
+                        {
+                            key = "value",
+                            type = "tab / submit",
+                        },
+                        context = new
+                        {
+                            theme = "default"
+                        }
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsTabSubmitAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestConfigFetch()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "config/fetch",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        data = new
+                        {
+                            key = "value",
+                            type = "config / fetch",
+                        },
+                        context = new
+                        {
+                            theme = "default"
+                        }
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsConfigFetchAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestConfigSubmit()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "config/submit",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        data = new
+                        {
+                            key = "value",
+                            type = "config / submit",
+                        },
+                        context = new
+                        {
+                            theme = "default"
+                        }
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsConfigSubmitAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestSigninVerifyState()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Name = "signin/verifyState",
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsSigninVerifyStateAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
+                Assert.Equal(200, ((InvokeResponse)_activitiesToSend[0].Value).Status);
+            }
+
+            [Fact]
+            public async Task TestOnEventActivity()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    ChannelId = Channels.Directline,
+                    Type = ActivityTypes.Event
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Single(bot.Record);
+                Assert.Equal("OnEventActivityAsync", bot.Record[0]);
+            }
+
+            [Fact]
+            public async Task TestMeetingStartEvent()
+            {
+                // Arrange
+                var startTimeBase = new DateTime(2024, 6, 5, 0, 1, 2);
+                var activity = new Activity
+                {
+                    ChannelId = Channels.Msteams,
+                    Type = ActivityTypes.Event,
+                    Name = "application/vnd.microsoft.meetingStart",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        StartTime = startTimeBase.ToString("o", CultureInfo.InvariantCulture) // "2025-06-05T00:01:02.0Z"
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnEventActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMeetingStartAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.Contains(startTimeBase.ToString(CultureInfo.InvariantCulture), _activitiesToSend[0].Text); // Date format differs between OSs, so we just Assert.Contains instead of Assert.Equals
+            }
+
+            [Fact]
+            public async Task TestMeetingEndEvent()
+            {
+                // Arrange
+                var endTimeBase = new DateTime(2024, 6, 5, 0, 1, 2);
+                var activity = new Activity
+                {
+                    ChannelId = Channels.Msteams,
+                    Type = ActivityTypes.Event,
+                    Name = "application/vnd.microsoft.meetingEnd",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        EndTime = endTimeBase.ToString("o", CultureInfo.InvariantCulture) //"2021-06-05T01:02:03.0Z"
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnEventActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMeetingEndAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.Contains(endTimeBase.ToString(CultureInfo.InvariantCulture), _activitiesToSend[0].Text); // Date format differs between OSs, so we just Assert.Contains instead of Assert.Equals
+            }
+
+            [Fact]
+            public async Task TeamsReadReceiptEvent()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    ChannelId = Channels.Msteams,
+                    Type = ActivityTypes.Event,
+                    Name = "application/vnd.microsoft.readReceipt",
+                    Value = JsonSerializer.SerializeToElement(new
+                    {
+                        lastReadMessageId = "10101010"
+                    }),
+                };
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await bot.OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnEventActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsReadReceiptAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.Equal("10101010", _activitiesToSend[0].Text);
+            }
+
+            [Fact]
+            public async Task TestMeetingParticipantsJoinEvent()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    ChannelId = Channels.Msteams,
+                    Type = ActivityTypes.Event,
+                    Name = "application/vnd.microsoft.meetingParticipantJoin",
+                    Value = JsonSerializer.SerializeToElement(
+                        new MeetingParticipantsEventDetails
+                        {
+                            Members =
+                            [
+                                new TeamsMeetingMember(
+                                    new TeamsChannelAccount { Id = "id", Name = "name"},
+                                    new UserMeetingDetails { Role = "role", InMeeting = true }
+                                )
+                            ]
+                        }
+                    ),
+                };
+
+                IActivity[] activitiesToSend = null;
+                void CaptureSend(IActivity[] arg)
+                {
+                    activitiesToSend = arg;
+                }
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnEventActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMeetingParticipantsJoinAsync", bot.Record[1]);
+                Assert.NotNull(activitiesToSend);
+                Assert.Single(activitiesToSend);
+                Assert.Equal("id", activitiesToSend[0].Text);
+            }
+
+            [Fact]
+            public async Task TestMeetingParticipantsLeaveEvent()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    ChannelId = Channels.Msteams,
+                    Type = ActivityTypes.Event,
+                    Name = "application/vnd.microsoft.meetingParticipantLeave",
+                    Value = JsonSerializer.SerializeToElement(
+                        new MeetingParticipantsEventDetails
+                        {
+                            Members =
+                            [
+                                new TeamsMeetingMember(
+                                    new TeamsChannelAccount { Id = "id", Name = "name"},
+                                    new UserMeetingDetails { Role = "role", InMeeting = true }
+                                )
+                            ]
+                        }
+                    ),
+                };
+
+                _activitiesToSend = null;
+
+                var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnEventActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMeetingParticipantsLeaveAsync", bot.Record[1]);
+                Assert.NotNull(_activitiesToSend);
+                Assert.Single(_activitiesToSend);
+                Assert.Equal("id", _activitiesToSend[0].Text);
+            }
+
+            [Fact]
+            public async Task TestMessageUpdateActivityTeamsMessageEdit()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "editMessage" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessageEditAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestMessageUpdateActivityTeamsMessageUndelete()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "undeleteMessage" },
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessageUndeleteAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestMessageUpdateActivityTeamsMessageUndelete_NoMsteams()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageUpdate,
+                    ChannelData = new TeamsChannelData { EventType = "undeleteMessage" },
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Single(bot.Record);
+                Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+            }
+
+            [Fact]
+            public async Task TestMessageUpdateActivityTeams_NoChannelData()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageUpdate,
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Single(bot.Record);
+                Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+            }
+
+            [Fact]
+            public async Task TestMessageDeleteActivityTeamsMessageSoftDelete()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageDelete,
+                    ChannelData = new TeamsChannelData { EventType = "softDeleteMessage" },
+                    ChannelId = Channels.Msteams
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Equal(2, bot.Record.Count);
+                Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+                Assert.Equal("OnTeamsMessageSoftDeleteAsync", bot.Record[1]);
+            }
+
+            [Fact]
+            public async Task TestMessageDeleteActivityTeamsMessageSoftDelete_NoMsteams()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageDelete,
+                    ChannelData = new TeamsChannelData { EventType = "softMessage" }
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Single(bot.Record);
+                Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+            }
+
+            [Fact]
+            public async Task TestMessageDeleteActivityTeams_NoChannelData()
+            {
+                // Arrange
+                var activity = new Activity
+                {
+                    Type = ActivityTypes.MessageDelete,
+                    ChannelId = Channels.Msteams,
+                };
+                var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+                // Act
+                var bot = new TestActivityHandler();
+                await ((IBot)bot).OnTurnAsync(turnContext);
+
+                // Assert
+                Assert.Single(bot.Record);
+                Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+            }
+
+        private class RosterHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+                // GetMembers (Team)
+                if (request.RequestUri.PathAndQuery.EndsWith("team-id/members"))
+                {
+                    var content = new TeamsPagedMembersResult
+                    {
+                        Members =
+                        [
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-1",
+                                Name = "name-1",
+                                GivenName = "givenName-1",
+                                Surname = "surname-1",
+                                Email = "email-1",
+                                UserPrincipalName = "userPrincipalName-1",
+                                UserRole = "userRole-1",
+                                TenantId = "tenantId-1",
+                            },
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-2",
+                                Name = "name-2",
+                                GivenName = "givenName-2",
+                                Surname = "surname-2",
+                                Email = "email-2",
+                                UserPrincipalName = "userPrincipalName-2",
+                                UserRole = "userRole-2",
+                                TenantId = "tenantId-2",
+                            },
+                        ]
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // GetMembers (Group Chat)
+                else if (request.RequestUri.PathAndQuery.EndsWith("conversation-id/members"))
+                {
+                    var content = new TeamsPagedMembersResult
+                    {
+                        Members =
+                        [
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-3",
+                                Name = "name-3",
+                                GivenName = "givenName-3",
+                                Surname = "surname-3",
+                                Email = "email-3",
+                                UserPrincipalName = "userPrincipalName-3",
+                                UserRole = "userRole-3",
+                                TenantId = "tenantId-3",
+                            },
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-4",
+                                Name = "name-4",
+                                GivenName = "givenName-4",
+                                Surname = "surname-4",
+                                Email = "email-4",
+                                UserPrincipalName = "userPrincipalName-4",
+                                UserRole = "userRole-4",
+                                TenantId = "tenantId-4",
+                            },
+                        ]
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+                else if (request.RequestUri.PathAndQuery.EndsWith("team-id/members/id-1") || request.RequestUri.PathAndQuery.EndsWith("conversation-id/members/id-1"))
+                {
+                    var content = new
+                    {
+                        Id = "id-1",
+                        ObjectId = "objectId-1",
+                        Name = "name-1",
+                        GivenName = "givenName-1",
+                        Surname = "surname-1",
+                        Email = "email-1",
+                        UserPrincipalName = "userPrincipalName-1",
+                        TenantId = "tenantId-1",
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                return Task.FromResult(response);
+            }
         }
-
-        //[Fact]
-        //public async Task TestMeetingParticipantsJoinEvent()
-        //{
-
-        // Arrange
-        //string json = @"{
-        //        Members: [
-        //            {
-        //                User: 
-        //                {
-        //                    Id: 'id', 
-        //                    Name: 'name'
-        //                }, 
-        //                Meeting: 
-        //                {
-        //                    Role: 'role', 
-        //                    InMeeting: true
-        //                }
-        //            }
-        //        ]}";
-
-        //var x = new TeamsMeetingMember(
-        //    new TeamsChannelAccount() { Id = "id", Name = "name" },
-        //    new UserMeetingDetails() { InMeeting = true, Role = "role" }
-        //);
-
-        //MeetingParticipantsEventDetails details = new MeetingParticipantsEventDetails();
-        //details.Members.Add(x);
-
-        ////var serialized = JsonSerializer.SerializeToElement(details);
-        //var serialized = SerializationExtensions.ToJson(details);
-        //var backAgain = SerializationExtensions.ToObject<MeetingParticipantsEventDetails>(serialized);
-
-        //Assert.True(backAgain.Members.Count == 1);
-
-
-        //var activity = new Activity
-        //{
-        //    ChannelId = Channels.Msteams,
-        //    Type = ActivityTypes.Event,
-        //    Name = "application/vnd.microsoft.meetingParticipantJoin",
-        //    Value = JsonSerializer.SerializeToElement(details)
-        //};
-
-
-        //var activity = new Activity
-        //{
-        //    ChannelId = Channels.Msteams,
-        //    Type = ActivityTypes.Event,
-        //    Name = "application/vnd.microsoft.meetingParticipantJoin",                
-        //    Value = JsonSerializer.SerializeToElement( new
-        //    {                    
-        //        Members = new[]
-        //        {
-        //            new
-        //            {
-        //                User = new
-        //                {
-        //                    Id = "id",
-        //                    Name = "name"
-        //                },
-        //                Meeting = new
-        //                {
-        //                    Role = "role",
-        //                    InMeeting = true
-        //                }
-        //            }
-        //        }
-        //    }),
-        //};
-
-
-        //Value = JObject.Parse(@"{
-        //    Members: [
-        //        {
-        //            User: 
-        //            {
-        //                Id: 'id', 
-        //                Name: 'name'
-        //            }, 
-        //            Meeting: 
-        //            {
-        //                Role: 'role', 
-        //                InMeeting: true
-        //            }
-        //        }
-        //    ]
-        //}"),
-        //
-
-        //var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-        //// Act
-        //var bot = new TestActivityHandler();
-        //await bot.OnTurnAsync(turnContext);
-
-        //// Assert
-        //Assert.Equal(2, bot.Record.Count);
-        //Assert.Equal("OnEventActivityAsync", bot.Record[0]);
-        //Assert.Equal("OnTeamsMeetingParticipantsJoinAsync", bot.Record[1]);
-        //Assert.NotNull(_activitiesToSend);
-        //Assert.Single(_activitiesToSend);
-        //Assert.Equal("id", _activitiesToSend[0].Text);
-        //}
-
-        //[Fact]
-        //public async Task TestMeetingParticipantsLeaveEvent()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        ChannelId = Channels.Msteams,
-        //        Type = ActivityTypes.Event,
-        //        Name = "application/vnd.microsoft.meetingParticipantLeave",
-        //        Value = JObject.Parse(@"{
-        //            Members: [
-        //                {
-        //                    User: 
-        //                    {
-        //                        Id: 'id', 
-        //                        Name: 'name'
-        //                    }, 
-        //                    Meeting: 
-        //                    {
-        //                        Role: 'role', 
-        //                        InMeeting: true
-        //                    }
-        //                }
-        //            ]
-        //        }"),
-        //    };
-
-        //    _activitiesToSend = null;
-
-        //    var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnEventActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMeetingParticipantsLeaveAsync", bot.Record[1]);
-        //    Assert.NotNull(_activitiesToSend);
-        //    Assert.Single(_activitiesToSend);
-        //    Assert.Equal("id", _activitiesToSend[0].Text);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageUpdateActivityTeamsMessageEdit()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageUpdate,
-        //        ChannelData = new TeamsChannelData { EventType = "editMessage" },
-        //        ChannelId = Channels.Msteams,
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMessageEditAsync", bot.Record[1]);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageUpdateActivityTeamsMessageUndelete()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageUpdate,
-        //        ChannelData = new TeamsChannelData { EventType = "undeleteMessage" },
-        //        ChannelId = Channels.Msteams,
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMessageUndeleteAsync", bot.Record[1]);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageUpdateActivityTeamsMessageUndelete_NoMsteams()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageUpdate,
-        //        ChannelData = new TeamsChannelData { EventType = "undeleteMessage" },
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Single(bot.Record);
-        //    Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageUpdateActivityTeams_NoChannelData()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageUpdate,
-        //        ChannelId = Channels.Msteams,
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Single(bot.Record);
-        //    Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageDeleteActivityTeamsMessageSoftDelete()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageDelete,
-        //        ChannelData = new TeamsChannelData { EventType = "softDeleteMessage" },
-        //        ChannelId = Channels.Msteams
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Equal(2, bot.Record.Count);
-        //    Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
-        //    Assert.Equal("OnTeamsMessageSoftDeleteAsync", bot.Record[1]);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageDeleteActivityTeamsMessageSoftDelete_NoMsteams()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageDelete,
-        //        ChannelData = new TeamsChannelData { EventType = "softMessage" }
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Single(bot.Record);
-        //    Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
-        //}
-
-        //[Fact]
-        //public async Task TestMessageDeleteActivityTeams_NoChannelData()
-        //{
-        //    // Arrange
-        //    var activity = new Activity
-        //    {
-        //        Type = ActivityTypes.MessageDelete,
-        //        ChannelId = Channels.Msteams,
-        //    };
-        //    var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
-
-        //    // Act
-        //    var bot = new TestActivityHandler();
-        //    await ((IBot)bot).OnTurnAsync(turnContext);
-
-        //    // Assert
-        //    Assert.Single(bot.Record);
-        //    Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
-        //}
-
-
-
-        //private class RosterHttpMessageHandler : HttpMessageHandler
-        //{
-        //    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        //    {
-        //        var response = new HttpResponseMessage(HttpStatusCode.OK);
-
-        //        // GetMembers (Team)
-        //        if (request.RequestUri.PathAndQuery.EndsWith("team-id/members"))
-        //        {
-        //            var content = new JArray
-        //            {
-        //                new JObject
-        //                {
-        //                    new JProperty("id", "id-1"),
-        //                    new JProperty("objectId", "objectId-1"),
-        //                    new JProperty("name", "name-1"),
-        //                    new JProperty("givenName", "givenName-1"),
-        //                    new JProperty("surname", "surname-1"),
-        //                    new JProperty("email", "email-1"),
-        //                    new JProperty("userPrincipalName", "userPrincipalName-1"),
-        //                    new JProperty("tenantId", "tenantId-1"),
-        //                },
-        //                new JObject
-        //                {
-        //                    new JProperty("id", "id-2"),
-        //                    new JProperty("objectId", "objectId-2"),
-        //                    new JProperty("name", "name-2"),
-        //                    new JProperty("givenName", "givenName-2"),
-        //                    new JProperty("surname", "surname-2"),
-        //                    new JProperty("email", "email-2"),
-        //                    new JProperty("userPrincipalName", "userPrincipalName-2"),
-        //                    new JProperty("tenantId", "tenantId-2"),
-        //                },
-        //            };
-        //            response.Content = new StringContent(content.ToString());
-        //        }
-
-        //        // GetMembers (Group Chat)
-        //        else if (request.RequestUri.PathAndQuery.EndsWith("conversation-id/members"))
-        //        {
-        //            var content = new JArray
-        //            {
-        //                new JObject
-        //                {
-        //                    new JProperty("id", "id-3"),
-        //                    new JProperty("objectId", "objectId-3"),
-        //                    new JProperty("name", "name-3"),
-        //                    new JProperty("givenName", "givenName-3"),
-        //                    new JProperty("surname", "surname-3"),
-        //                    new JProperty("email", "email-3"),
-        //                    new JProperty("userPrincipalName", "userPrincipalName-3"),
-        //                    new JProperty("tenantId", "tenantId-3"),
-        //                },
-        //                new JObject
-        //                {
-        //                    new JProperty("id", "id-4"),
-        //                    new JProperty("objectId", "objectId-4"),
-        //                    new JProperty("name", "name-4"),
-        //                    new JProperty("givenName", "givenName-4"),
-        //                    new JProperty("surname", "surname-4"),
-        //                    new JProperty("email", "email-4"),
-        //                    new JProperty("userPrincipalName", "userPrincipalName-4"),
-        //                    new JProperty("tenantId", "tenantId-4"),
-        //                },
-        //            };
-        //            response.Content = new StringContent(content.ToString());
-        //        }
-        //        else if (request.RequestUri.PathAndQuery.EndsWith("team-id/members/id-1") || request.RequestUri.PathAndQuery.EndsWith("conversation-id/members/id-1"))
-        //        {
-        //            var content = new JObject
-        //                {
-        //                    new JProperty("id", "id-1"),
-        //                    new JProperty("objectId", "objectId-1"),
-        //                    new JProperty("name", "name-1"),
-        //                    new JProperty("givenName", "givenName-1"),
-        //                    new JProperty("surname", "surname-1"),
-        //                    new JProperty("email", "email-1"),
-        //                    new JProperty("userPrincipalName", "userPrincipalName-1"),
-        //                    new JProperty("tenantId", "tenantId-1"),
-        //                };
-        //            response.Content = new StringContent(content.ToString());
-        //        }
-
-        //        return Task.FromResult(response);
-        //    }
-        //}
     }
 }

--- a/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsInfoTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsInfoTests.cs
@@ -1,0 +1,1609 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.BotBuilder.Teams;
+using Microsoft.Agents.Connector;
+using Microsoft.Agents.Connector.Teams;
+using Microsoft.Agents.Connector.Types;
+using Microsoft.Agents.Core.Interfaces;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Teams.Models;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Tests.Teams
+{
+    public class TeamsInfoTests
+    {
+        private const string ExpectedActivityId = "activity-id";
+        private const string ExpectedTeamsChannelId = "teams-channel-id";
+
+        private readonly RestTeamsConnectorClient _connectorClient;
+
+
+        public TeamsInfoTests()
+        {
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory.Setup(a => a.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient(new RosterHttpMessageHandler()));
+
+            _connectorClient = new RestTeamsConnectorClient(new Uri("http://localhost/"), httpFactory.Object, null);
+        }
+
+        [Fact]
+        public async Task SendMessageToTeamsChannelAsync_ShouldReturnConversationReferenceUsingAdapter()
+        {
+            var expectedConversationId = "conversation-id";
+            var activity = CreateTestActivity("Test-SendMessageToTeamsChannelAsync");
+            var adapter = new TestCreateConversationAdapter(ExpectedActivityId, expectedConversationId);
+            var turnContext = new TurnContext(adapter, activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            turnContext.Activity.ServiceUrl = "https://test.coffee";
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task SendMessageToTeamsChannelAsync_ShouldReturnConversationReference()
+        {
+            var expectedAppId = "app-id";
+            var expectedServiceUrl = "service-url";
+            var expectedConversationId = "conversation-id";
+            var requestActivity = new Activity { ServiceUrl = expectedServiceUrl };
+            var adapter = new TestCreateConversationAdapter(ExpectedActivityId, expectedConversationId);
+
+            var turnContextMock = new Mock<ITurnContext>();
+            turnContextMock.Setup(tc => tc.Activity).Returns(requestActivity);
+            turnContextMock.Setup(tc => tc.Adapter).Returns(adapter);
+
+            var activity = CreateTestActivity("Test-SendMessageToTeamsChannelAsync");
+
+            var reference = await TeamsInfo.SendMessageToTeamsChannelAsync(turnContextMock.Object, activity, ExpectedTeamsChannelId, expectedAppId, CancellationToken.None);
+
+            Assert.Equal(expectedConversationId, reference.Item1.Conversation.Id);
+            Assert.Equal(ExpectedActivityId, reference.Item2);
+            Assert.Equal(expectedAppId, adapter.AppId);
+            Assert.Equal(Channels.Msteams, adapter.ChannelId);
+            Assert.Equal(expectedServiceUrl, adapter.ServiceUrl);
+            Assert.Null(adapter.Audience);
+
+            var adapterChannelData = adapter.ConversationParameters.ChannelData;
+            var channel = adapterChannelData.GetType().GetProperty("Channel").GetValue(adapterChannelData, null);
+            var id = channel.GetType().GetProperty("Id").GetValue(channel, null);
+
+            Assert.Equal(ExpectedTeamsChannelId, id);
+            Assert.Equal(adapter.ConversationParameters.Activity, activity);
+        }
+
+        [Fact]
+        public async Task GetMeetingInfoAsync_ShouldReturnMeetingInfo()
+        {
+            var channelData = new TeamsChannelData
+            {
+                Meeting = new TeamsMeetingInfo
+                {
+                    Id = "meeting-id"
+                }
+            };
+            var activity = CreateTestActivity("Test-GetMeetingInfoAsync", channelData);
+
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetTeamDetailsAsync_ShouldReturnTeamDetails()
+        {
+            var activity = CreateTestActivity("Test-GetTeamDetailsAsync");
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetPagedTeamMembersAsync_ShouldReturnTeamMembersList()
+        {
+            var activity = CreateTestActivity("Test-TeamGetPagedTeamMembersAsync");
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetPagedMembersAsync_ShouldReturnGroupChatMembersList()
+        {
+            var channelData = new TeamsChannelData
+            {
+                Team = new TeamInfo(),
+            };
+            var activity = CreateTestActivity("Test-GroupChat-GetPagedMembersAsync", channelData);
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetChannelsAsync_ShouldReturnChannelsList()
+        {
+            var activity = CreateTestActivity("Test-GetChannelsAsync");
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetMeetingParticipantAsync_ShouldReturnMeetingParticipantInfo()
+        {
+            var channelData = new TeamsChannelData
+            {
+                Meeting = new TeamsMeetingInfo { Id = "meetingId-1" },
+                Tenant = new TenantInfo { Id = "tenantId-1" },
+            };
+            var activity = CreateTestActivity("Test-GetParticipantAsync", channelData);
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetMemberAsync_ShouldReturnAccountInfo()
+        {
+            var activity = CreateTestActivity("Test-GetMemberAsync");
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Fact]
+        public async Task GetMemberAsync_ShouldReturnAccountInfoWhenNoTeamId()
+        {
+            var channelData = new TeamsChannelData
+            {
+                Team = new TeamInfo(),
+            };
+            var activity = CreateTestActivity("Test-GetMemberAsync", channelData);
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("202")]
+        [InlineData("207")]
+        [InlineData("400")]
+        [InlineData("403")]
+        public async Task SendMeetingNotificationAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            //     202: accepted
+            //     207: if the notifications are sent only to parital number of recipients because 
+            //                 the validation on some recipients’ ids failed or some recipients were not found in the roster. 
+            //             • In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot 
+            //                 (ex: if a bot sent encrypted user MRIs, return encrypted one).
+
+            //     400: when Meeting Notification request payload validation fails. For instance, 
+            //         • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
+            //         • Surface: 
+            //             o Surface list is empty or null 
+            //             o Surface type is invalid 
+            //             o Duplicative surface type exists in one payload
+            //     403: if the bot is not allowed to send the notification.
+            //         In this case, the payload should contain more detail error message.
+            //         There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
+            //         the bot does not have a correct RSC permission for a specific surface type, etc
+            var activity = new Activity
+            {
+                Type = "targetedMeetingNotification",
+                Text = "Test-SendMeetingNotificationAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    //Hack for test.use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("201")]
+        [InlineData("400")]
+        [InlineData("403")]
+        [InlineData("429")]
+        public async Task SendMessageToListOfUsersAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 201: created
+            // 400: when send message to list of users request payload validation fails.
+            // 403: if the bot is not allowed to send messages.
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-SendMessageToListOfUsersAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("201")]
+        [InlineData("400")]
+        [InlineData("403")]
+        [InlineData("429")]
+        public async Task SendMessageToAllUsersInTenantAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 201: created
+            // 400: when send message to list of users request payload validation fails.
+            // 403: if the bot is not allowed to send messages.
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-SendMessageToAllUsersInTenantAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("201")]
+        [InlineData("400")]
+        [InlineData("403")]
+        [InlineData("404")]
+        [InlineData("429")]
+        public async Task SendMessageToAllUsersInTeamAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 201: created
+            // 400: when send message to list of users request payload validation fails.
+            // 403: if the bot is not allowed to send messages.
+            // 404: when Team is not found.
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-SendMessageToAllUsersInTeamAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("201")]
+        [InlineData("400")]
+        [InlineData("403")]
+        [InlineData("429")]
+        public async Task SendMessageToListOfChannelsAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 201: created
+            // 400: when send message to list of channels request payload validation fails.
+            // 403: if the bot is not allowed to send messages.
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-SendMessageToListOfChannelsAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("200")]
+        [InlineData("400")]
+        [InlineData("429")]
+        public async Task GetOperationStateAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 200: ok
+            // 400: for requests with invalid operationId (Which should be of type GUID).
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-GetOperationStateAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("200")]
+        [InlineData("400")]
+        [InlineData("429")]
+        public async Task GetPagedFailedEntriesAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 200: ok
+            // 400: for requests with invalid operationId (Which should be of type GUID).
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-GetPagedFailedEntriesAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("200")]
+        [InlineData("400")]
+        [InlineData("429")]
+        public async Task CancelOperationAsync_ShouldReturnExpectedStatusCode(string statusCode)
+        {
+            // 200: Ok for successful cancelled operations (Operations in state completed, or failed will not change state to cancel but still return 200)
+            // 400: for requests with invalid operationId (Which should be of type GUID).
+            // 429: too many requests for throttled requests.
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-CancelOperationAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+            var handler = new TestTeamsActivityHandler();
+
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        private static Activity CreateTestActivity(string text, object channelData = null)
+        {
+            var activityChannelData = channelData;
+
+            activityChannelData ??= new TeamsChannelData
+            {
+                Team = new TeamInfo { Id = "team-id" },
+            };
+
+            return new Activity
+            {
+                Type = "message",
+                Text = text,
+                ChannelId = Channels.Msteams,
+                Conversation = new ConversationAccount { Id = "conversation-id" },
+                From = new ChannelAccount { Id = "id-1", AadObjectId = "participantId-1" },
+                ServiceUrl = "https://test.coffee",
+                ChannelData = activityChannelData,
+            };
+        }
+
+        private class TestTeamsActivityHandler : TeamsActivityHandler
+        {
+            public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+            {
+                await base.OnTurnAsync(turnContext, cancellationToken);
+
+                switch (turnContext.Activity.Text)
+                {
+                    case "Test-GetTeamDetailsAsync":
+                        await CallGetTeamDetailsAsync(turnContext);
+                        break;
+                    case "Test-TeamGetPagedTeamMembersAsync":
+                        await CallTeamGetPagedTeamMembersAsync(turnContext);
+                        break;
+                    case "Test-GroupChat-GetPagedMembersAsync":
+                        await CallGroupChatGetPagedMembersAsync(turnContext);
+                        break;
+                    case "Test-GetChannelsAsync":
+                        await CallGetChannelsAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToTeamsChannelAsync":
+                        await CallSendMessageToTeamsChannelAsync(turnContext);
+                        break;
+                    case "Test-GetMemberAsync":
+                        await CallTeamGetMemberAsync(turnContext);
+                        break;
+                    case "Test-GetParticipantAsync":
+                        await CallTeamsInfoGetParticipantAsync(turnContext);
+                        break;
+                    case "Test-GetMeetingInfoAsync":
+                        await CallTeamsInfoGetMeetingInfoAsync(turnContext);
+                        break;
+                    case "Test-SendMeetingNotificationAsync":
+                        await CallSendMeetingNotificationAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToListOfUsersAsync":
+                        await CallSendMessageToListOfUsersAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToAllUsersInTenantAsync":
+                        await CallSendMessageToAllUsersInTenantAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToAllUsersInTeamAsync":
+                        await CallSendMessageToAllUsersInTeamAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToListOfChannelsAsync":
+                        await CallSendMessageToListOfChannelsAsync(turnContext);
+                        break;
+                    case "Test-GetOperationStateAsync":
+                        await CallGetOperationStateAsync(turnContext);
+                        break;
+                    case "Test-GetPagedFailedEntriesAsync":
+                        await CallGetPagedFailedEntriesAsync(turnContext);
+                        break;
+                    case "Test-CancelOperationAsync":
+                        await CallCancelOperationAsync(turnContext);
+                        break;
+                    default:
+                        Assert.True(false);
+                        break;
+                }
+            }
+
+            private static async Task CallSendMessageToTeamsChannelAsync(ITurnContext turnContext)
+            {
+                var message = MessageFactory.Text("hi");
+                var channelId = Channels.Msteams;
+                var appId = "app-id";
+                var cancelToken = new CancellationToken();
+
+                var reference = await TeamsInfo.SendMessageToTeamsChannelAsync(turnContext, message, channelId, appId, cancelToken);
+
+                Assert.Equal(ExpectedActivityId, reference.Item1.ActivityId);
+                Assert.Equal(channelId, reference.Item1.ChannelId);
+                Assert.Equal(turnContext.Activity.ServiceUrl, reference.Item1.ServiceUrl);
+                Assert.Equal(ExpectedActivityId, reference.Item2);
+            }
+
+            private static async Task CallGetTeamDetailsAsync(ITurnContext turnContext)
+            {
+                var teamDetails = await TeamsInfo.GetTeamDetailsAsync(turnContext);
+
+                Assert.Equal("team-id", teamDetails.Id);
+                Assert.Equal("team-name", teamDetails.Name);
+                Assert.Equal("team-aadgroupid", teamDetails.AadGroupId);
+            }
+
+            private static async Task CallTeamGetPagedTeamMembersAsync(ITurnContext turnContext)
+            {
+                var teamsMembers = await TeamsInfo.GetPagedTeamMembersAsync(turnContext);
+
+                Assert.Equal("id-1", teamsMembers.Members[0].Id);
+                Assert.Equal("name-1", teamsMembers.Members[0].Name);
+                Assert.Equal("givenName-1", teamsMembers.Members[0].GivenName);
+                Assert.Equal("surname-1", teamsMembers.Members[0].Surname);
+                Assert.Equal("userPrincipalName-1", teamsMembers.Members[0].UserPrincipalName);
+
+                Assert.Equal("id-2", teamsMembers.Members[1].Id);
+                Assert.Equal("name-2", teamsMembers.Members[1].Name);
+                Assert.Equal("givenName-2", teamsMembers.Members[1].GivenName);
+                Assert.Equal("surname-2", teamsMembers.Members[1].Surname);
+                Assert.Equal("userPrincipalName-2", teamsMembers.Members[1].UserPrincipalName);
+            }
+
+            private static async Task CallTeamGetMemberAsync(ITurnContext turnContext)
+            {
+                var member = await TeamsInfo.GetMemberAsync(turnContext, turnContext.Activity.From.Id);
+
+                Assert.Equal("id-1", member.Id);
+                Assert.Equal("name-1", member.Name);
+                Assert.Equal("givenName-1", member.GivenName);
+                Assert.Equal("surname-1", member.Surname);
+                Assert.Equal("userPrincipalName-1", member.UserPrincipalName);
+            }
+
+            private static async Task CallTeamsInfoGetParticipantAsync(ITurnContext turnContext)
+            {
+                var participant = await TeamsInfo.GetMeetingParticipantAsync(turnContext);
+
+                Assert.Equal("Organizer", participant.Meeting.Role);
+                Assert.Equal("meetigConversationId-1", participant.Conversation.Id);
+                Assert.Equal("userPrincipalName-1", participant.User.UserPrincipalName);
+            }
+
+            private static async Task CallTeamsInfoGetMeetingInfoAsync(ITurnContext turnContext)
+            {
+                var meeting = await TeamsInfo.GetMeetingInfoAsync(turnContext);
+
+                Assert.Equal("meeting-id", meeting.Details.Id);
+                Assert.Equal("organizer-id", meeting.Organizer.Id);
+                Assert.Equal("meetingConversationId-1", meeting.Conversation.Id);
+            }
+
+            private static MeetingNotificationBase GetTargetedMeetingNotification(ChannelAccount from)
+            {
+                var recipients = new List<string> { from.Id };
+
+                if (from.Name == "207")
+                {
+                    recipients.Add("failingid");
+                }
+
+                var meetingStageSurface = new MeetingStageSurface<TaskModuleContinueResponse>
+                {
+                    Content = new TaskModuleContinueResponse
+                    {
+                        Value = new TaskModuleTaskInfo
+                        {
+                            Title = "title here",
+                            Height = 3,
+                            Width = 2,
+                        }
+                    },
+                    ContentType = ContentType.Task
+                };
+
+                var meetingTabIconSurface = new MeetingTabIconSurface
+                {
+                    TabEntityId = "test tab entity id"
+                };
+
+                var value = new TargetedMeetingNotificationValue
+                {
+                    Recipients = recipients,
+                    Surfaces = [meetingStageSurface, meetingTabIconSurface]
+                };
+
+                var obo = new OnBehalfOf
+                {
+                    DisplayName = from.Name,
+                    Mri = from.Id
+                };
+
+                var channelData = new MeetingNotificationChannelData
+                {
+                    OnBehalfOfList = [obo]
+                };
+
+                return new TargetedMeetingNotification
+                {
+                    Value = value,
+                    ChannelData = channelData
+                };
+            }
+
+            private async Task CallSendMeetingNotificationAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+
+                try
+                {
+                    var failedParticipants = await TeamsInfo.SendMeetingNotificationAsync(turnContext, GetTargetedMeetingNotification(from), "meeting-id").ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "207":
+                            Assert.Equal("failingid", failedParticipants.RecipientsFailureInfo.First().RecipientMri);
+                            break;
+                        case "202":
+                            Assert.Null(failedParticipants);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (ErrorResponseException ex)
+                {
+                    var errorResponse = ex.Body;
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Equal("BadSyntax", ex.Body.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Equal("BotNotInConversationRoster", ex.Body.Error.Code);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+            }
+
+            private static async Task CallGroupChatGetPagedMembersAsync(ITurnContext turnContext)
+            {
+                var teamsMembers = await TeamsInfo.GetPagedMembersAsync(turnContext);
+
+                Assert.Equal("id-3", teamsMembers.Members[0].Id);
+                Assert.Equal("name-3", teamsMembers.Members[0].Name);
+                Assert.Equal("givenName-3", teamsMembers.Members[0].GivenName);
+                Assert.Equal("surname-3", teamsMembers.Members[0].Surname);
+                Assert.Equal("userPrincipalName-3", teamsMembers.Members[0].UserPrincipalName);
+
+                Assert.Equal("id-4", teamsMembers.Members[1].Id);
+                Assert.Equal("name-4", teamsMembers.Members[1].Name);
+                Assert.Equal("givenName-4", teamsMembers.Members[1].GivenName);
+                Assert.Equal("surname-4", teamsMembers.Members[1].Surname);
+                Assert.Equal("userPrincipalName-4", teamsMembers.Members[1].UserPrincipalName);
+            }
+
+            private static async Task CallGetChannelsAsync(ITurnContext turnContext)
+            {
+                var channels = (await TeamsInfo.GetTeamChannelsAsync(turnContext)).ToArray();
+
+                Assert.Equal("channel-id-1", channels[0].Id);
+                Assert.Equal("channel-id-2", channels[1].Id);
+                Assert.Equal("channel-name-2", channels[1].Name);
+                Assert.Equal("channel-id-3", channels[2].Id);
+                Assert.Equal("channel-name-3", channels[2].Name);
+            }
+
+            private async Task CallSendMessageToListOfUsersAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+                var members = new List<TeamMember>()
+                {
+                    new ("member-1"),
+                    new ("member-2"),
+                    new ("member-3"),
+                };
+                var tenantId = "tenant-id";
+
+                try
+                {
+                    var operationId = await TeamsInfo.SendMessageToListOfUsersAsync(turnContext, turnContext.Activity, members, tenantId).ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "201":
+                            Assert.Equal("operation-1", operationId);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("Forbidden", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+            }
+
+            private async Task CallSendMessageToAllUsersInTenantAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+                var tenantId = "tenant-id";
+
+                try
+                {
+                    var operationId = await TeamsInfo.SendMessageToAllUsersInTenantAsync(turnContext, turnContext.Activity, tenantId).ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "201":
+                            Assert.Equal("operation-1", operationId);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("Forbidden", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+            }
+
+            private async Task CallSendMessageToAllUsersInTeamAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+                var teamId = "team-id";
+                var tenantId = "tenant-id";
+
+                try
+                {
+                    var operationId = await TeamsInfo.SendMessageToAllUsersInTeamAsync(turnContext, turnContext.Activity, teamId, tenantId).ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "201":
+                            Assert.Equal("operation-1", operationId);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("Forbidden", errorResponse.Error.Code);
+                            break;
+                        case "404":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("NotFound", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+            }
+
+            private async Task CallSendMessageToListOfChannelsAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+                var members = new List<TeamMember>()
+                {
+                    new ("channel-1"),
+                    new ("channel-2"),
+                    new ("channel-3"),
+                };
+                var tenantId = "tenant-id";
+
+                try
+                {
+                    var operationId = await TeamsInfo.SendMessageToListOfChannelsAsync(turnContext, turnContext.Activity, members, tenantId).ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "201":
+                            Assert.Equal("operation-1", operationId);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("Forbidden", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from.Name}.");
+                    }
+                }
+            }
+
+            private async Task CallGetOperationStateAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From.Name;
+                var operationId = "operation-id*";
+                var response = new BatchOperationState
+                {
+                    State = "state-1",
+                    TotalEntriesCount = 1
+                };
+                response.StatusMap.Add(400, 1);
+
+                try
+                {
+                    var operationResponse = await TeamsInfo.GetOperationStateAsync(turnContext, operationId + from).ConfigureAwait(false);
+
+                    switch (from)
+                    {
+                        case "200":
+                            Assert.Equal(response.ToString(), operationResponse.ToString());
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from}.");
+                    }
+                }
+            }
+
+            private async Task CallGetPagedFailedEntriesAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From.Name;
+                var operationId = "operation-id*";
+                var response = new BatchFailedEntriesResponse
+                {
+                    ContinuationToken = "continuation-token",
+                };
+                response.FailedEntries.Add(
+                    new BatchFailedEntry
+                    {
+                        EntryId = "entry-1",
+                        Error = "400 User not found"
+                    });
+
+                try
+                {
+                    var operationResponse = await TeamsInfo.GetPagedFailedEntriesAsync(turnContext, operationId + from).ConfigureAwait(false);
+
+                    switch (from)
+                    {
+                        case "200":
+                            Assert.Equal(response.ToString(), operationResponse.ToString());
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+                    switch (from)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from}.");
+                    }
+                }
+            }
+
+            private async Task CallCancelOperationAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From.Name;
+                var operationId = "operation-id*";
+                AggregateException exception = null;
+
+                try
+                {
+                    await TeamsInfo.CancelOperationAsync(turnContext, operationId + from).ConfigureAwait(false);
+
+                    switch (from)
+                    {
+                        case "200":
+                            Assert.Null(exception);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    exception = ex;
+                    var firstException = exception.InnerExceptions.First();
+                    ErrorResponseException httpException;
+                    var errorResponse = new ErrorResponse();
+                    switch (from)
+                    {
+                        case "400":
+                            Assert.Single(exception.InnerExceptions);
+                            httpException = (ErrorResponseException)firstException;
+                            errorResponse = httpException.Body;
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, exception.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(ErrorResponseException)} with response status code {from}.");
+                    }
+                }
+            }
+        }
+
+        private class RosterHttpMessageHandler : HttpMessageHandler
+        {
+            protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                };
+
+                // GetTeamDetails
+                if (request.RequestUri.PathAndQuery.EndsWith("team-id"))
+                {
+                    var content = new
+                    {
+                        id = "team-id",
+                        name = "team-name",
+                        aadGroupId = "team-aadgroupid",
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // SendMessageToThreadInTeams
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/conversations"))
+                {
+                    var content = new
+                    {
+                        id = "id123",
+                        serviceUrl = "https://serviceUrl/",
+                        activityId = ExpectedActivityId,
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // GetChannels
+                else if (request.RequestUri.PathAndQuery.EndsWith("team-id/conversations"))
+                {
+                    var content = new ConversationList
+                    {
+                        Conversations =
+                        [
+                            new ChannelInfo { Id = "channel-id-1" },
+                            new ChannelInfo { Id = "channel-id-2", Name = "channel-name-2" },
+                            new ChannelInfo { Id = "channel-id-3", Name = "channel-name-3"  },
+                        ],
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // GetPagedMembers (Team)
+                else if (request.RequestUri.PathAndQuery.EndsWith("team-id/pagedmembers"))
+                {
+                    var content = new TeamsPagedMembersResult
+                    {
+                        Members =
+                        [
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-1",
+                                Name = "name-1",
+                                GivenName = "givenName-1",
+                                Surname = "surname-1",
+                                Email = "email-1",
+                                UserPrincipalName = "userPrincipalName-1",
+                                UserRole = "userRole-1",
+                                TenantId = "tenantId-1",
+                            },
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-2",
+                                Name = "name-2",
+                                GivenName = "givenName-2",
+                                Surname = "surname-2",
+                                Email = "email-2",
+                                UserPrincipalName = "userPrincipalName-2",
+                                UserRole = "userRole-2",
+                                TenantId = "tenantId-2",
+                            },
+                        ]
+                    };
+
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // GetPagedMembers (Group Chat)
+                else if (request.RequestUri.PathAndQuery.EndsWith("conversation-id/pagedmembers"))
+                {
+                    var content = new TeamsPagedMembersResult
+                    {
+                        Members =
+                        [
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-3",
+                                Name = "name-3",
+                                GivenName = "givenName-3",
+                                Surname = "surname-3",
+                                Email = "email-3",
+                                UserPrincipalName = "userPrincipalName-3",
+                                UserRole = "userRole-3",
+                                TenantId = "tenantId-3",
+                            },
+                            new TeamsChannelAccount
+                            {
+                                Id = "id-4",
+                                Name = "name-4",
+                                GivenName = "givenName-4",
+                                Surname = "surname-4",
+                                Email = "email-4",
+                                UserPrincipalName = "userPrincipalName-4",
+                                UserRole = "userRole-4",
+                                TenantId = "tenantId-4",
+                            },
+                        ]
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // Get Member
+                else if (request.RequestUri.PathAndQuery.EndsWith("team-id/members/id-1") || request.RequestUri.PathAndQuery.EndsWith("conversation-id/members/id-1"))
+                {
+                    var content = new
+                    {
+                        id = "id-1",
+                        objectId = "objectId-1",
+                        name = "name-1",
+                        givenName = "givenName-1",
+                        surname = "surname-1",
+                        email = "email-1",
+                        userPrincipalName = "userPrincipalName-1",
+                        tenantId = "tenantId-1",
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // Get participant
+                else if (request.RequestUri.PathAndQuery.EndsWith("v1/meetings/meetingId-1/participants/participantId-1?tenantId=tenantId-1"))
+                {
+                    var content = new
+                    {
+                        user = new { userPrincipalName = "userPrincipalName-1" },
+                        meeting = new { role = "Organizer" },
+                        conversation = new { Id = "meetigConversationId-1" },
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // Get meeting details
+                else if (request.RequestUri.PathAndQuery.EndsWith("v1/meetings/meeting-id"))
+                {
+                    var content = new
+                    {
+                        details = new { id = "meeting-id" },
+                        organizer = new { id = "organizer-id" },
+                        conversation = new { id = "meetingConversationId-1" },
+                    };
+                    response.Content = new StringContent(JsonSerializer.Serialize(content));
+                }
+
+                // SendMeetingNotification
+                else if (request.RequestUri.PathAndQuery.EndsWith("v1/meetings/meeting-id/notification"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                    var payload = JsonDocument.Parse(requestBody);
+                    JsonElement root = payload.RootElement;
+                    var value = root.GetProperty("value");
+                    var recipients = value.GetProperty("recipients").Deserialize<List<string>>(options);
+                    var channelData = root.GetProperty("channelData").Deserialize<MeetingNotificationChannelData>(options);
+                    var obo = channelData.OnBehalfOfList.First();
+
+                    // hack displayname as expected status code, for testing
+                    switch (obo.DisplayName)
+                    {
+                        case "207":
+                            var failureInfo = new MeetingNotificationRecipientFailureInfo { RecipientMri = recipients.First(r => !r.Equals(obo.Mri, StringComparison.OrdinalIgnoreCase)) };
+                            var infos = new MeetingNotificationResponse
+                            {
+                                RecipientsFailureInfo = new List<MeetingNotificationRecipientFailureInfo> { failureInfo }
+                            };
+
+                            response.Content = new StringContent(JsonSerializer.Serialize(infos));
+                            response.StatusCode = HttpStatusCode.MultiStatus;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BotNotInConversationRoster\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "400":
+                            var error = new ErrorResponse(new Error("BadSyntax"));
+                            response.Content = new StringContent(JsonSerializer.Serialize(error));
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // SendMessageToListOfUsers
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/users/"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var payload = JsonDocument.Parse(requestBody);
+                    JsonElement root = payload.RootElement;
+                    var activity = root.GetProperty("activity").Deserialize<Activity>(options);
+
+                    // hack From.Name as expected status code, for testing
+                    switch (activity.From.Name)
+                    {
+                        case "201":
+                            response.Content = new StringContent("operation-1");
+                            response.StatusCode = HttpStatusCode.Created;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // SendMessageToAllUsersInTenant
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/tenant/"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var payload = JsonDocument.Parse(requestBody);
+                    JsonElement root = payload.RootElement;
+                    var requestActivity = root.GetProperty("activity").Deserialize<Activity>(options);
+
+                    // hack From.Name as expected status code, for testing
+                    switch (requestActivity.From.Name)
+                    {
+                        case "201":
+                            response.Content = new StringContent("operation-1");
+                            response.StatusCode = HttpStatusCode.Created;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // SendMessageToAllUsersInTeam
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/team/"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var payload = JsonDocument.Parse(requestBody);
+                    JsonElement root = payload.RootElement;
+                    var requestActivity = root.GetProperty("activity").Deserialize<Activity>(options);
+
+                    // hack From.Name as expected status code, for testing
+                    switch (requestActivity.From.Name)
+                    {
+                        case "201":
+                            response.Content = new StringContent("operation-1");
+                            response.StatusCode = HttpStatusCode.Created;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "404":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"NotFound\"}}");
+                            response.StatusCode = HttpStatusCode.NotFound;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // SendMessageToListOfChannels
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/channels/"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var payload = JsonDocument.Parse(requestBody);
+                    JsonElement root = payload.RootElement;
+                    var requestActivity = root.GetProperty("activity").Deserialize<Activity>(options);
+
+                    // hack From.Name as expected status code, for testing
+                    switch (requestActivity.From.Name)
+                    {
+                        case "201":
+                            response.Content = new StringContent("operation-1");
+                            response.StatusCode = HttpStatusCode.Created;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // GetOperationState
+                else if (request.RequestUri.PathAndQuery.Contains("v3/batch/conversation/operation-id") && request.Method.ToString() == "GET")
+                {
+                    // get status from url for testing
+                    var uri = request.RequestUri.PathAndQuery;
+                    var status = uri[(uri.IndexOf("%2A") + 3)..];
+
+                    switch (status)
+                    {
+                        case "200":
+                            var content = new
+                            {
+                                State = "state-1",
+                                Response = new { StatusMap = new { StatusMap = 1 } },
+                                TotalEntriesCount = 1,
+                            };
+                            response.Content = new StringContent(JsonSerializer.Serialize(content));
+                            response.StatusCode = HttpStatusCode.OK;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // GetPagedFailedEntries
+                else if (request.RequestUri.PathAndQuery.Contains("v3/batch/conversation/failedentries/operation-id"))
+                {
+                    // Get status from url for testing
+                    var uri = request.RequestUri.PathAndQuery;
+                    var status = uri[(uri.IndexOf("%2A") + 3)..];
+
+                    switch (status)
+                    {
+                        case "200":
+                            var content = new BatchFailedEntriesResponse
+                            {
+                                ContinuationToken = "token-1",
+                                FailedEntries = new List<BatchFailedEntry> { new BatchFailedEntry { EntryId = "entry-1", Error = "400 user not found" } },
+                            };
+                            response.Content = new StringContent(JsonSerializer.Serialize(content));
+                            response.StatusCode = HttpStatusCode.OK;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // CancelOperation
+                else if (request.RequestUri.PathAndQuery.Contains("v3/batch/conversation/operation-id") && request.Method.ToString() == "DELETE")
+                {
+                    // get status from url for testing
+                    var uri = request.RequestUri.PathAndQuery;
+                    var status = uri[(uri.IndexOf("%2A") + 3)..];
+
+                    switch (status)
+                    {
+                        case "200":
+                            response.StatusCode = HttpStatusCode.OK;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                return response;
+            }
+        }
+
+        private class TestCreateConversationAdapter(string activityId, string conversationId) : IChannelAdapter
+        {
+            private readonly string _activityId = activityId;
+
+            private readonly string _conversationId = conversationId;
+
+            public string AppId { get; set; }
+
+            public string ChannelId { get; set; }
+
+            public string ServiceUrl { get; set; }
+
+            public string Audience { get; set; }
+
+            public ConversationParameters ConversationParameters { get; set; }
+            public Func<ITurnContext, Exception, Task> OnTurnError { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public IMiddlewareSet MiddlewareSet => throw new NotImplementedException();
+
+            public Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task ContinueConversationAsync(string botId, IActivity continuationActivity, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task ContinueConversationAsync(string botId, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task CreateConversationAsync(string botAppId, string channelId, string serviceUrl, string audience, ConversationParameters conversationParameters, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                AppId = botAppId;
+                ChannelId = channelId;
+                ServiceUrl = serviceUrl;
+                Audience = audience;
+                ConversationParameters = conversationParameters;
+
+                var activity = new Activity { Id = _activityId, ChannelId = channelId, ServiceUrl = serviceUrl, Conversation = new ConversationAccount { Id = _conversationId } };
+
+                var mockTurnContext = new Mock<ITurnContext>();
+                mockTurnContext.Setup(tc => tc.Activity).Returns(activity);
+
+                callback(mockTurnContext.Object, cancellationToken);
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<InvokeResponse> ProcessActivityAsync(ClaimsIdentity claimsIdentity, IActivity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, IActivity activity, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IChannelAdapter Use(IMiddleware middleware)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsSSOTokenExchangeMiddlewareTests.cs
+++ b/src/tests/Microsoft.Agents.BotBuilder.Tests/Teams/TeamsSSOTokenExchangeMiddlewareTests.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.BotBuilder.Teams;
+using Microsoft.Agents.BotBuilder.Testing;
+using Microsoft.Agents.Core.Interfaces;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Serialization;
+using Microsoft.Agents.Storage;
+using Xunit;
+
+namespace Microsoft.Agents.BotBuilder.Tests.Teams
+{
+    public class TeamsSSOTokenExchangeMiddlewareTests
+    {
+        private const string ConnectionName = "ConnectionName";
+        private const string FakeExchangeableItem = "Fake token";
+        private const string ExchangeId = "exchange id";
+        private const string TeamsUserId = "teams.user.id";
+        private const string Token = "token";
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullStorage()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamsSSOTokenExchangeMiddleware(null, ConnectionName));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullConnectionName()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamsSSOTokenExchangeMiddleware(new MemoryStorage(), null));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnEmptyConnectionName()
+        {
+            Assert.Throws<ArgumentException>(() => new TeamsSSOTokenExchangeMiddleware(new MemoryStorage(), string.Empty));
+        }
+
+        [Fact]
+        public async Task ExchangedTokenAsync_ShouldReturnToken()
+        {
+            bool wasCalled = false;
+            var adapter = new TeamsSSOAdapter(CreateConversationReference())
+               .Use(new TeamsSSOTokenExchangeMiddleware(new MemoryStorage(), ConnectionName));
+
+            adapter.AddExchangeableToken(ConnectionName, Channels.Msteams, TeamsUserId, FakeExchangeableItem, Token);
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                // note the Middleware should not cause the Responded flag to be set
+                Assert.False(context.Responded);
+                wasCalled = true;
+                await context.SendActivityAsync("processed", cancellationToken: cancellationToken);
+                await Task.CompletedTask;
+            })
+                .Send("test")
+                .AssertReply("processed")
+                .StartTestAsync();
+
+            Assert.True(wasCalled, "Delegate was not called");
+        }
+
+        [Fact]
+        public async Task ExchangedTokenAsync_ShouldSentInvokeResponseOnSecondSend()
+        {
+            int calledCount = 0;
+            var adapter = new TeamsSSOAdapter(CreateConversationReference())
+               .Use(new TeamsSSOTokenExchangeMiddleware(new MemoryStorage(), ConnectionName));
+
+            adapter.AddExchangeableToken(ConnectionName, Channels.Msteams, TeamsUserId, FakeExchangeableItem, Token);
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                // note the Middleware should not cause the Responded flag to be set
+                Assert.False(context.Responded);
+                calledCount++;
+                await context.SendActivityAsync("processed", cancellationToken: cancellationToken);
+                await Task.CompletedTask;
+            })
+                .Send("test")
+                .AssertReply("processed")
+                .Send("test")
+                .AssertReply((activity) =>
+                {
+                    // When the 2nd message goes through, it is not processed due to deduplication
+                    // but an invokeResponse of 200 status with empty body is sent back
+                    Assert.Equal(ActivityTypes.InvokeResponse, activity.Type);
+                    var invokeResponse = (activity as Activity).Value as InvokeResponse;
+                    Assert.Null(invokeResponse.Body);
+                    Assert.Equal(200, invokeResponse.Status);
+                })
+                .StartTestAsync();
+
+            Assert.Equal(1, calledCount);
+        }
+
+        [Fact]
+        public async Task ExchangedTokenAsync_ShouldNotExchangeTokenOnPreconditionFailed()
+        {
+            bool wasCalled = false;
+            var adapter = new TeamsSSOAdapter(CreateConversationReference())
+               .Use(new TeamsSSOTokenExchangeMiddleware(new MemoryStorage(), ConnectionName));
+
+            // since this test does not setup adapter.AddExchangeableToken, the exchange will not happen
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                wasCalled = true;
+                await Task.CompletedTask;
+            })
+                .Send("test")
+                .AssertReply((activity) =>
+                {
+                    Assert.Equal(ActivityTypes.InvokeResponse, activity.Type);
+                    var invokeResponse = (activity as Activity).Value as InvokeResponse;
+                    var tokenExchangeRequest = invokeResponse.Body as TokenExchangeInvokeResponse;
+                    Assert.Equal(ConnectionName, tokenExchangeRequest.ConnectionName);
+                    Assert.Equal(ExchangeId, tokenExchangeRequest.Id);
+                    Assert.Equal(412, invokeResponse.Status); //412:PreconditionFailed
+                })
+                .StartTestAsync();
+
+            Assert.False(wasCalled, "Delegate was called");
+        }
+
+        [Fact]
+        public async Task ExchangedTokenAsync_ShouldNotExchangeTokenOnDirectLineChannel()
+        {
+            var wasCalled = false;
+            var adapter = new TeamsSSOAdapter(CreateConversationReference(Channels.Directline))
+               .Use(new TeamsSSOTokenExchangeMiddleware(new MemoryStorage(), ConnectionName));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                wasCalled = true;
+                await context.SendActivityAsync("processed", cancellationToken: cancellationToken);
+                await Task.CompletedTask;
+            })
+                .Send("test")
+                .AssertReply("processed")
+                .StartTestAsync();
+
+            Assert.True(wasCalled, "Delegate was not called");
+        }
+
+        private static ConversationReference CreateConversationReference(string channelId = Channels.Msteams)
+        {
+            return new ConversationReference
+            {
+                ChannelId = channelId,
+                ServiceUrl = "https://test.com",
+                User = new ChannelAccount(TeamsUserId, TeamsUserId),
+                Bot = new ChannelAccount("bot", "Bot"),
+                Conversation = new ConversationAccount(false, "convo1", "Conversation1"),
+                Locale = "en-us",
+            };
+        }
+
+        private class TeamsSSOAdapter(ConversationReference conversationReference) : TestAdapter(conversationReference)
+        {
+            public override Task SendTextToBotAsync(string userSays, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                return ProcessActivityAsync(MakeTokenExchangeActivity(), callback, cancellationToken);
+            }
+
+            public Activity MakeTokenExchangeActivity()
+            {
+                return new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    Locale = this.Locale ?? "en-us",
+                    From = Conversation.User,
+                    Recipient = Conversation.Bot,
+                    Conversation = Conversation.Conversation,
+                    ServiceUrl = Conversation.ServiceUrl,
+                    Id = Guid.NewGuid().ToString(),
+                    Name = SignInConstants.TokenExchangeOperationName,
+                    Value = ProtocolJsonSerializer.ToJsonElements(new TokenExchangeInvokeRequest()
+                    {
+                        Token = FakeExchangeableItem,
+                        Id = ExchangeId,
+                        ConnectionName = ConnectionName
+                    })
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR creates unit tests to cover the classes in the **_Microsoft.Agents.BotBuilder.Teams_** project.

> NOTE: These tests were part of the **_0001-Add-unit-tests-for-Protocols.Teams.Adapter.patch_** file.

## Detailed Changes
- Migrated and adapted the following test classes: _TeamsInfoTests_, _TeamsActivityExtensionsTests_, _TeamsSSOTokenExchangeMiddlewareTests_.
- Added tests to cover missing code paths in _TeamsActivityHandlerTests_.
- Fixed the following bugs:
   - In **RestTeamsOperations**, we Included the case for StatusCode 207 (used in the Teams batch operations). Added a condition to handle empty http contents, and changed POST with GET in the call to 'GetOperationState'. Also, we removed the _using_ condition of the httpClient as it was being disposed of preventing the retry-task functionality ([link](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.ihttpclientfactory.createclient?view=net-9.0-pp#remarks)). 
- In **ConversationsRestClient**, we added default values for pageSize and CancellationToken.
- In **TeamsSSOTokenExchangeMiddleware**, we improved the connectionName validation.

## Testing
The following image shows the new tests passing.
![image](https://github.com/user-attachments/assets/0f467a62-8e34-490a-ae1e-c7c2fcf44fcb)