### PR TITLE
Fix Stream DeliveryMode

### DIFF
--- a/src/libraries/Client/Microsoft.Agents.Client/HttpAgentClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Client/HttpAgentClient.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Agents.Client
             var activityClone = CreateSendActivity(agentConversationId, activity, relatesTo);
             activityClone.DeliveryMode = DeliveryModes.Stream;
 
-            return InnerSendActivityStreamedAsync(activity, useAnonymous, cancellationToken);
+            return InnerSendActivityStreamedAsync(activityClone, useAnonymous, cancellationToken);
         }
 
         public async IAsyncEnumerable<object> InnerSendActivityStreamedAsync(IActivity activity, bool useAnonymous = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description
This PR fixes an issue with the Stream DeliveryMode not being set correctly when the Agent1 sent a message to Agent2 using the Streamed functionality.

## Detailed Changes
- Send the correctly activity clone that sets the delivery mode to Stream.

## Testing
The following image shows the Agent1 and Agent2 working.
![image](https://github.com/user-attachments/assets/b49d1542-49a2-4895-b163-d1c26138ef28)