### PR TITLE
Fix Agent-To-Agent communication by retrieving claims from JWT token in ChannelApiController

### DIFF
--- a/src/libraries/Hosting/AspNetCore/ChannelApiController.cs
+++ b/src/libraries/Hosting/AspNetCore/ChannelApiController.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Agents.Core.Models;
@@ -42,7 +41,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                 return null;
             }
 
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnSendToConversationAsync(claimsIdentity, conversationId, activity).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -63,7 +62,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                 return null;
             }
 
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnReplyToActivityAsync(claimsIdentity, conversationId, activityId, activity).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -84,7 +83,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                 return null;
             }
 
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnUpdateActivityAsync(claimsIdentity, conversationId, activityId, activity).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -98,7 +97,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpDelete("v3/conversations/{conversationId}/activities/{activityId}")]
         public virtual async Task DeleteActivityAsync(string conversationId, string activityId)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             await _handler.OnDeleteActivityAsync(claimsIdentity, conversationId, activityId).ConfigureAwait(false);
         }
 
@@ -114,7 +113,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpGet("v3/conversations/{conversationId}/activities/{activityId}/members")]
         public virtual async Task<IActionResult> GetActivityMembersAsync(string conversationId, string activityId)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnGetActivityMembersAsync(claimsIdentity, conversationId, activityId).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -127,7 +126,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpPost("v3/conversations")]
         public virtual async Task<IActionResult> CreateConversationAsync([FromBody] ConversationParameters parameters)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnCreateConversationAsync(claimsIdentity, parameters).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -140,7 +139,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpGet("v3/conversations")]
         public virtual async Task<IActionResult> GetConversationsAsync(string continuationToken = null)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnGetConversationsAsync(claimsIdentity, continuationToken).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -153,7 +152,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpGet("v3/conversations/{conversationId}/members")]
         public virtual async Task<IActionResult> GetConversationMembersAsync(string conversationId)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnGetConversationMembersAsync(claimsIdentity, conversationId).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -167,7 +166,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpGet("v3/conversations/{conversationId}/members/{userId}")]
         public virtual async Task<IActionResult> GetConversationMemberAsync(string userId, string conversationId)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnGetConversationMemberAsync(claimsIdentity, userId, conversationId).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -182,7 +181,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpGet("v3/conversations/{conversationId}/pagedmembers")]
         public virtual async Task<IActionResult> GetConversationPagedMembersAsync(string conversationId, int pageSize = -1, string continuationToken = null)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnGetConversationPagedMembersAsync(claimsIdentity, conversationId, pageSize, continuationToken).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -196,7 +195,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpDelete("v3/conversations/{conversationId}/members/{memberId}")]
         public virtual async Task DeleteConversationMemberAsync(string conversationId, string memberId)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             await _handler.OnDeleteConversationMemberAsync(claimsIdentity, conversationId, memberId).ConfigureAwait(false);
         }
 
@@ -209,7 +208,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpPost("v3/conversations/{conversationId}/activities/history")]
         public virtual async Task<IActionResult> SendConversationHistoryAsync(string conversationId, [FromBody] Transcript history)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnSendConversationHistoryAsync(claimsIdentity, conversationId, history).ConfigureAwait(false);
             return new JsonResult(result);
         }
@@ -223,7 +222,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         [HttpPost("v3/conversations/{conversationId}/attachments")]
         public virtual async Task<IActionResult> UploadAttachmentAsync(string conversationId, [FromBody] AttachmentData attachmentUpload)
         {
-            var claimsIdentity = User?.Identity as ClaimsIdentity;
+            var claimsIdentity = HttpHelper.GetClaimsIdentity(Request);
             var result = await _handler.OnUploadAttachmentAsync(claimsIdentity, conversationId, attachmentUpload).ConfigureAwait(false);
             return new JsonResult(result);
         }

--- a/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
+++ b/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
@@ -13,8 +13,6 @@ using Microsoft.Agents.Builder;
 using System.Text;
 using Microsoft.Agents.Core.Errors;
 using Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue;
-using System.Linq;
-using System.IdentityModel.Tokens.Jwt;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Agents.Hosting.AspNetCore
@@ -129,24 +127,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                 // Deserialize the incoming Activity
                 var activity = await HttpHelper.ReadRequestAsync<IActivity>(httpRequest).ConfigureAwait(false);
 
-                // If Auth is not configured, we still need the claims from the JWT token.
-                // Currently, the stack does rely on certain Claims.  If the Bearer token
-                // was sent, we can get them from there.  The JWT token is NOT validated though.
-                var claimsIdentity = (ClaimsIdentity)httpRequest.HttpContext.User.Identity;
-                if (!claimsIdentity.IsAuthenticated && !claimsIdentity.Claims.Any())
-                {
-                    var auth = httpRequest.Headers.Authorization;
-                    if (auth.Count != 0)
-                    {
-                        var authHeaderValue = auth.First();
-                        var authValues = authHeaderValue.Split(' ');
-                        if (authValues.Length == 2 && authValues[0].Equals("bearer", StringComparison.OrdinalIgnoreCase))
-                        {
-                            var jwt = new JwtSecurityToken(authValues[1]);
-                            claimsIdentity = new ClaimsIdentity(jwt.Claims);
-                        }
-                    }
-                }
+                var claimsIdentity = HttpHelper.GetClaimsIdentity(httpRequest);
 
                 if (!IsValidChannelActivity(activity))
                 {


### PR DESCRIPTION
## Description
This PR fixes an issue in Agent-To-Agent communication. Agent1 found an HTTP 401 error while attempting to forward Agent2's message to the channel, as the Authorization header was not populated correctly.

## Detailed Changes
- Added a `GetClaimsIdentity` method in `HttpHelper` class to retrieve the _claimsIdentity_ from the JWT token when Auth is not configured.
- Call the new method in `ChannelApiController` methods.
- Replace the code in `CloudAdapter's ProcessAsync` to call the new method instead.

## Testing
These images show the Agent-To-Agent sample working with anonymous authentication as well as using credentials.
![image](https://github.com/user-attachments/assets/7b147557-b44c-42df-8505-4bdc03986c36)