### PR TITLE
[#413] HeaderPropagation: User-Agent

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationContext.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationContext.cs
@@ -89,7 +89,17 @@ public class HeaderPropagationContext()
 #endif
                     break;
                 case HeaderPropagationEntryAction.Append when headerExists:
-                    StringValues newValue = requestHeader.Concat(header.Value).ToArray();
+                    StringValues newValue;
+                    if (string.Equals(header.Key, "user-agent", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Special handling for User-Agent to concatenate values with a space.
+                        newValue = new StringValues(string.Join(" ", [.. requestHeader, header.Value]));
+                    }
+                    else
+                    {
+                        // For other headers, use default concat which separate the list with a comma.
+                        newValue = requestHeader.Concat(header.Value).ToArray();
+                    }
                     result[header.Key] = newValue;
                     break;
                 case HeaderPropagationEntryAction.Propagate when headerExists:

--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationContext.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationContext.cs
@@ -89,18 +89,16 @@ public class HeaderPropagationContext()
 #endif
                     break;
                 case HeaderPropagationEntryAction.Append when headerExists:
-                    StringValues newValue;
                     if (string.Equals(header.Key, "user-agent", StringComparison.OrdinalIgnoreCase))
                     {
                         // Special handling for User-Agent to concatenate values with a space.
-                        newValue = new StringValues(string.Join(" ", [.. requestHeader, header.Value]));
+                        result[header.Key] = new StringValues(string.Join(" ", [.. requestHeader, header.Value]));
                     }
                     else
                     {
                         // For other headers, use default concat which separate the list with a comma.
-                        newValue = requestHeader.Concat(header.Value).ToArray();
+                        result[header.Key] = requestHeader.Concat(header.Value).ToArray();
                     }
-                    result[header.Key] = newValue;
                     break;
                 case HeaderPropagationEntryAction.Propagate when headerExists:
                     result[header.Key] = requestHeader;

--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationEntryCollection.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationEntryCollection.cs
@@ -62,7 +62,16 @@ public class HeaderPropagationEntryCollection
             if (_entries.TryGetValue(key, out var entry))
             {
                 // If the key already exists, append the new value to the existing one.
-                newValue = StringValues.Concat(entry.Value, value);
+                if (string.Equals(key, "user-agent", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    // Special handling for User-Agent to concatenate values with a space.
+                    newValue = new StringValues(string.Join(" ", [.. entry.Value, value]));
+                }
+                else
+                {
+                    // For other headers, use default concat which separate the list with a comma.
+                    newValue = StringValues.Concat(entry.Value, value);
+                }
             }
 
             _entries[key] = new HeaderPropagationEntry

--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationEntryCollection.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationEntryCollection.cs
@@ -57,7 +57,7 @@ public class HeaderPropagationEntryCollection
     {
         lock (_optionsLock)
         {
-            StringValues newValue;
+            StringValues newValue = value;
 
             if (_entries.TryGetValue(key, out var entry))
             {
@@ -77,7 +77,7 @@ public class HeaderPropagationEntryCollection
             _entries[key] = new HeaderPropagationEntry
             {
                 Key = key,
-                Value = !StringValues.IsNullOrEmpty(newValue) ? newValue : value,
+                Value = newValue,
                 Action = HeaderPropagationEntryAction.Append
             };
         }

--- a/src/tests/Microsoft.Agents.Core.Tests/HeaderPropagationTests.cs
+++ b/src/tests/Microsoft.Agents.Core.Tests/HeaderPropagationTests.cs
@@ -51,20 +51,23 @@ namespace Microsoft.Agents.Core.HeaderPropagation.Tests
             // Arrange
             HeaderPropagationContext.HeadersToPropagate.Append("User-Agent", "extra-value-1");
             HeaderPropagationContext.HeadersToPropagate.Append("User-Agent", "extra-value-2");
-            
+            HeaderPropagationContext.HeadersToPropagate.Append("Accept", "text/html");
+
             HeaderPropagationContext.HeadersFromRequest = new Dictionary<string, StringValues>
             {
                 { "x-ms-correlation-id", new StringValues("1234") },
-                { "User-Agent", new StringValues("Value-1") }
+                { "User-Agent", new StringValues("Value-1") },
+                { "Accept", new StringValues("text/plain") }
             };
 
             // Act
             var filteredHeaders = HeaderPropagationContext.HeadersFromRequest;
 
             // Assert
-            Assert.Equal(2, filteredHeaders.Count);
+            Assert.Equal(3, filteredHeaders.Count);
             Assert.Equal("1234", filteredHeaders["x-ms-correlation-id"]);
-            Assert.Equal("Value-1,extra-value-1,extra-value-2", filteredHeaders["User-Agent"]);
+            Assert.Equal("Value-1 extra-value-1 extra-value-2", filteredHeaders["User-Agent"]);
+            Assert.Equal("text/plain,text/html", filteredHeaders["Accept"]);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes # 413

## Description
This PR adds a condition to the **_Append_** operation in **_HeaderPropagation_** to concatenate `User-Agent` values using a space instead of a comma.

### Detailed Changes
- Introduced a condition to use a space as the separator when appending values for the **_User-Agent_** header in:
   -  HeaderPropagationContext
   - HeaderPropagationEntryCollection
- Updated unit tests to cover both scenarios:
   - Appending values for the _User-Agent_ header (space-separated)
   - Appending values for other headers (comma-separated)

## Testing
This image shows the unit tests passing after the changes.
<img width="1205" height="289" alt="image" src="https://github.com/user-attachments/assets/d16cf3e1-4831-4388-84b7-49721514e011" />
 