### PR TITLE
Add oAuthCard fallback for M365 Copilot Chat

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/AgentApplication.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/AgentApplication.cs
@@ -777,6 +777,13 @@ namespace Microsoft.Agents.Builder.App
             AssertionHelpers.ThrowIfNull(turnContext, nameof(turnContext));
             AssertionHelpers.ThrowIfNull(turnContext.Activity, nameof(turnContext.Activity));
 
+            // Ignore incoming typing activities as it causes duplication in the authorization process.
+            // Note: while testing, WebChat was the only one at the moment that sent typing activities.
+            if (turnContext.Activity.Type == ActivityTypes.Typing)
+            {
+                return;
+            }
+
             try
             {
                 // Start typing timer if configured


### PR DESCRIPTION
Fixes # 526

## Description
This PR adds a conditional to send an AdaptiveCard that mimics an oAuthCard for M365 Copilot Chat, as it does not support oAuthCard yet.

> [!Note]
> This will not work with token exchange operations.

## Testing
The following image shows the comparison between WebChat, MS Teams and M365 Copilot Chat.
<img width="2481" height="1022" alt="image" src="https://github.com/user-attachments/assets/7711bc6b-812f-4c6e-8529-0eb1c32b0488" />

