### PR TITLE
Update HeaderPropagation assembly to use source generator

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core.Analyzers/HeaderPropagationSourceGenerator.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core.Analyzers/HeaderPropagationSourceGenerator.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.Agents.Core.Analyzers
+{
+    /// <summary>
+    /// Creates assembly HeaderPropagationAssemblyAttribute to register all HeaderPropagationAttribute types.
+    /// </summary>
+    [Generator]
+    public class HeaderPropagationSourceGenerator : IIncrementalGenerator
+    {
+        internal const string HeaderPropagationAttributeFullName = "Microsoft.Agents.Core.HeaderPropagation.HeaderPropagationAttribute";
+        internal const string HeaderPropagationAssemblyAttributeFullName = "Microsoft.Agents.Core.HeaderPropagation.HeaderPropagationAssemblyAttribute";
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            IncrementalValueProvider<ImmutableArray<string?>> types =
+                context.SyntaxProvider
+                    .ForAttributeWithMetadataName(
+                        HeaderPropagationAttributeFullName,
+                        (node, _) => node is ClassDeclarationSyntax || node is StructDeclarationSyntax,
+                        (context, ct) =>
+                            (context.TargetSymbol as INamedTypeSymbol)?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                    )
+                    .Where(static x => x is not null)
+                    .Collect();
+
+            context.RegisterSourceOutput(types, static (context, types) =>
+            {
+                if (types.IsDefaultOrEmpty)
+                {
+                    return;
+                }
+
+                var source = string.Join("\r\n", types.Select(x => $"[assembly: {HeaderPropagationAssemblyAttributeFullName}(typeof({x}))]"));
+
+                context.AddSource("HeaderPropagationAssemblyAttributes.g.cs", SourceText.From(source, Encoding.UTF8));
+            });
+        }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationAssemblyAttribute.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationAssemblyAttribute.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Agents.Core.HeaderPropagation;
+
+/// <summary>
+/// Attribute containing a type with a LoadHeaders method to be called when initializing header propagation.
+/// </summary>
+/// <param name="type">Declared type containing static LoadHeaders method to call.</param>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class HeaderPropagationAssemblyAttribute(Type type) : Attribute
+{
+    public readonly Type InitType = type;
+
+    internal static void InitHeaderPropagation()
+    {
+        // Register handler for new assembly loads. This is needed because
+        // C# doesn't load a package until accessed.
+        AppDomain.CurrentDomain.AssemblyLoad += (s, o) => InitAssembly(o.LoadedAssembly);
+
+        // Call header propagation init on currently loaded assemblies.
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            InitAssembly(assembly);
+        }
+    }
+
+    private static void InitAssembly(Assembly assembly)
+    {
+        foreach (var type in GetLoadOnInitTypes(assembly))
+        {
+#if !NETSTANDARD
+            if (!typeof(IHeaderPropagationAttribute).IsAssignableFrom(type))
+            {
+                throw new InvalidOperationException($"Type '{type.FullName}' is marked with [HeaderPropagation] but does not implement IHeaderPropagationAttribute.");
+            }
+#endif
+
+            var init = type.GetMethod("LoadHeaders", BindingFlags.Static | BindingFlags.Public);
+
+            if (init == null)
+            {
+                continue;
+            }
+
+            init.Invoke(null, [HeaderPropagationContext.HeadersToPropagate]);
+        }
+    }
+
+    private static IEnumerable<Type> GetLoadOnInitTypes(Assembly assembly) =>
+        assembly
+            .GetCustomAttributes(typeof(HeaderPropagationAssemblyAttribute), false)?
+            .OfType<HeaderPropagationAssemblyAttribute>()
+            .Select(x => x.InitType)
+            ?? Array.Empty<Type>();
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationAttribute.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationAttribute.cs
@@ -1,78 +1,17 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Reflection;
 
 namespace Microsoft.Agents.Core.HeaderPropagation;
 
 /// <summary>
-/// Attribute to load headers for header propagation.
-/// This attribute should be applied to classes that implement the <see cref="IHeaderPropagationAttribute"/> interface.
+/// Attribute to register a type for header propagation initialization.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class)]
-public class HeaderPropagationAttribute : Attribute
+/// <remarks>
+/// Should be applied to classes that implement the <see cref="IHeaderPropagationAttribute"/> interface.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class HeaderPropagationAttribute : Attribute
 {
-    internal static void LoadHeaders()
-    {
-        // Init newly loaded assemblies
-        AppDomain.CurrentDomain.AssemblyLoad += (s, o) => LoadHeadersAssembly(o.LoadedAssembly);
-
-        // And all the ones we currently have loaded
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            LoadHeadersAssembly(assembly);
-        }
-    }
-
-    private static void LoadHeadersAssembly(Assembly assembly)
-    {
-        foreach (var type in GetLoadHeadersTypes(assembly))
-        {
-#if !NETSTANDARD
-            if (!typeof(IHeaderPropagationAttribute).IsAssignableFrom(type))
-            {
-                throw new InvalidOperationException(
-                    $"Type '{type.FullName}' is marked with [HeaderPropagation] but does not implement IHeaderPropagationAttribute.");
-            }
-#endif
-
-            var loadHeaders = type.GetMethod(nameof(LoadHeaders), BindingFlags.Static | BindingFlags.Public);
-
-            if (loadHeaders == null)
-            {
-                continue;
-            }
-
-            loadHeaders.Invoke(assembly, [HeaderPropagationContext.HeadersToPropagate]);
-        }
-    }
-
-    private static IEnumerable<Type> GetLoadHeadersTypes(Assembly assembly)
-    {
-        IList<Type> result = [];
-
-        Type[] types;
-
-        try
-        {
-            types = assembly.GetTypes();
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Trace.WriteLine($"HeaderPropagationAttribute.GetLoadHeadersTypes: {ex.Message}");
-            return result;
-        }
-
-        foreach (Type type in types)
-        {
-            if (type.GetCustomAttributes(typeof(HeaderPropagationAttribute), true).Length > 0)
-            {
-                result.Add(type);
-            }
-        }
-
-        return result;
-    }
 }

--- a/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationContext.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/HeaderPropagation/HeaderPropagationContext.cs
@@ -19,7 +19,7 @@ public class HeaderPropagationContext()
 
     static HeaderPropagationContext()
     {
-        HeaderPropagationAttribute.LoadHeaders();
+        HeaderPropagationAssemblyAttribute.InitHeaderPropagation();
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes # 686

## Description
This PR updates the HeaderPropagation assembly functionality to use the source generator pattern to register the assembly.

## Testing
The following image shows the header propagation functionality continues working.
<img width="985" height="1011" alt="image" src="https://github.com/user-attachments/assets/6802c82b-2e8d-41f5-be02-b52b4d0aa373" />
