### PR TITLE
[#853] Add Teams signin in progress message and cancel option

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/AzureBotUserAuthorization.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/AzureBotUserAuthorization.cs
@@ -203,6 +203,18 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
 
         private async Task<TokenResponse> OnContinueFlow(ITurnContext turnContext, FlowState state, CancellationToken cancellationToken)
         {
+            if (ShouldCancelFlow(turnContext))
+            {
+                await ResetFlowStateAsync(turnContext, state, cancellationToken).ConfigureAwait(false);
+
+                if (!string.IsNullOrWhiteSpace(_settings.SignInCancelledMessage))
+                {
+                    await turnContext.SendActivityAsync(_settings.SignInCancelledMessage, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+
+                throw new AuthException("User cancelled authorization", AuthExceptionReason.UserCancelled);
+            }
+
             TokenResponse tokenResponse;
 
             try
@@ -248,7 +260,26 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
         {
             return turnContext.Activity.ChannelId.IsParentChannel(Channels.Msteams)
                 && turnContext.Activity.IsType(ActivityTypes.Message)
+                && !ShouldCancelFlow(turnContext)
                 && !string.IsNullOrWhiteSpace(_settings.TeamsSignInInProgressMessage);
+        }
+
+        private bool ShouldCancelFlow(ITurnContext turnContext)
+        {
+            if (!turnContext.Activity.IsType(ActivityTypes.Message) || string.IsNullOrWhiteSpace(turnContext.Activity.Text))
+            {
+                return false;
+            }
+
+            foreach (var command in _settings.CancelSignInCommands ?? [])
+            {
+                if (!string.IsNullOrWhiteSpace(command) && string.Equals(turnContext.Activity.Text.Trim(), command.Trim(), StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private async Task<FlowState> GetFlowStateAsync(ITurnContext turnContext, CancellationToken cancellationToken)
@@ -266,6 +297,14 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
                     { key, state }
                 };
             await _storage.WriteAsync(items, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task ResetFlowStateAsync(ITurnContext turnContext, FlowState state, CancellationToken cancellationToken)
+        {
+            state.FlowStarted = false;
+            state.FlowExpires = DateTime.MinValue;
+            state.ContinueCount = 0;
+            await ResetStateAsync(turnContext, cancellationToken).ConfigureAwait(false);
         }
 
         private string GetStorageKey(ITurnContext turnContext)

--- a/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/AzureBotUserAuthorization.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/AzureBotUserAuthorization.cs
@@ -220,7 +220,11 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
 
             if (tokenResponse == null)
             {
-                if (!OAuthFlow.IsTokenExchangeRequestInvoke(turnContext))
+                if (ShouldSendTeamsSignInInProgressMessage(turnContext))
+                {
+                    await turnContext.SendActivityAsync(_settings.TeamsSignInInProgressMessage, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else if (!OAuthFlow.IsTokenExchangeRequestInvoke(turnContext))
                 {
                     state.ContinueCount++;
                     if (state.ContinueCount >= _settings.InvalidSignInRetryMax)
@@ -238,6 +242,13 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
 
             state.FlowStarted = false;
             return tokenResponse;
+        }
+
+        private bool ShouldSendTeamsSignInInProgressMessage(ITurnContext turnContext)
+        {
+            return turnContext.Activity.ChannelId.IsParentChannel(Channels.Msteams)
+                && turnContext.Activity.IsType(ActivityTypes.Message)
+                && !string.IsNullOrWhiteSpace(_settings.TeamsSignInInProgressMessage);
         }
 
         private async Task<FlowState> GetFlowStateAsync(ITurnContext turnContext, CancellationToken cancellationToken)

--- a/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/OAuthSettings.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/OAuthSettings.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Agents.Builder.UserAuth.TokenService
 {
@@ -36,6 +37,8 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
         public string InvalidSignInRetryMessage { get; set; } = "Invalid sign in code. Please enter the 6-digit code.";
         public int InvalidSignInRetryMax { get; set; } = 2;
         public string TeamsSignInInProgressMessage { get; set; } = "Please finish signing and wait for completion";
+        public IList<string> CancelSignInCommands { get; set; } = ["-cancel"];
+        public string SignInCancelledMessage { get; set; } = "Sign in cancelled.";
 
         /// <summary>
         /// Gets or sets the number of milliseconds the prompt waits for the user to authenticate.

--- a/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/OAuthSettings.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/OAuthSettings.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
 
         public string InvalidSignInRetryMessage { get; set; } = "Invalid sign in code. Please enter the 6-digit code.";
         public int InvalidSignInRetryMax { get; set; } = 2;
+        public string TeamsSignInInProgressMessage { get; set; } = "Please finish signing and wait for completion";
 
         /// <summary>
         /// Gets or sets the number of milliseconds the prompt waits for the user to authenticate.

--- a/src/tests/Microsoft.Agents.Builder.Tests/AzureBotUserAuthorizationTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/AzureBotUserAuthorizationTests.cs
@@ -1369,6 +1369,110 @@ namespace Microsoft.Agents.Builder.Tests
             Assert.Equal("teams-sso-token", finalResult.Token);
         }
 
+        [Fact]
+        public async Task TeamsSso_CancelCommand_DuringFlow_CancelsFlow_AndSendsConfiguredMessage()
+        {
+            // Arrange
+            var settings = new OAuthSettings
+            {
+                AzureBotOAuthConnectionName = ConnectionName,
+                Timeout = 900000,
+                TeamsSignInInProgressMessage = "Please finish signing and wait for completion",
+                CancelSignInCommands = ["-cancel", "/cancel"],
+                SignInCancelledMessage = "Authentication cancelled."
+            };
+
+            var sentActivities = new List<IActivity>();
+            var mockTokenClient = new Mock<IUserTokenClient>();
+
+            mockTokenClient
+                .Setup(c => c.GetTokenOrSignInResourceAsync(It.IsAny<string>(), It.IsAny<IActivity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenOrSignInResourceResponse
+                {
+                    SignInResource = new SignInResource
+                    {
+                        SignInLink = "https://login.test.com",
+                        TokenExchangeResource = new TokenExchangeResource { Id = "id", Uri = "uri" }
+                    }
+                });
+
+            var handler = new AzureBotUserAuthorization(HandlerName, _storage, _mockConnections.Object, settings);
+
+            var startContext = CreateTeamsMessageTurnContext(mockTokenClient.Object);
+            var startResult = await handler.SignInUserAsync(startContext, forceSignIn: true, cancellationToken: CancellationToken.None);
+            Assert.Null(startResult);
+
+            sentActivities.Clear();
+            var cancelActivity = CreateMessageActivity(Channels.Msteams, "-cancel");
+            var cancelContext = CreateTurnContextWithCapture(cancelActivity, mockTokenClient.Object, sentActivities);
+
+            var ex = await Assert.ThrowsAsync<AuthException>(() =>
+                handler.SignInUserAsync(cancelContext, cancellationToken: CancellationToken.None));
+
+            Assert.Equal(AuthExceptionReason.UserCancelled, ex.Cause);
+            var cancelMessage = sentActivities.OfType<Activity>().LastOrDefault(a => a.Type == ActivityTypes.Message);
+            Assert.NotNull(cancelMessage);
+            Assert.Equal(settings.SignInCancelledMessage, cancelMessage.Text);
+            Assert.DoesNotContain(sentActivities, a => a.Type == ActivityTypes.Message && ((Activity)a).Text == settings.TeamsSignInInProgressMessage);
+
+            // Flow state should be cleared so a new message starts a fresh flow instead of continuing the old one.
+            sentActivities.Clear();
+            var restartContext = CreateTurnContextWithCapture(CreateTeamsMessageTurnContext(mockTokenClient.Object).Activity, mockTokenClient.Object, sentActivities);
+            var restartResult = await handler.SignInUserAsync(restartContext, forceSignIn: true, cancellationToken: CancellationToken.None);
+
+            Assert.Null(restartResult);
+            Assert.Contains(sentActivities.OfType<Activity>(), a => a.Attachments?.Any(att => att.ContentType == OAuthCard.ContentType) == true);
+        }
+
+        [Fact]
+        public async Task SignInUserAsync_CancelCommand_IsCaseInsensitive_AndDoesNotUseRetryBudget()
+        {
+            // Arrange
+            var settings = new OAuthSettings
+            {
+                AzureBotOAuthConnectionName = ConnectionName,
+                Timeout = 900000,
+                InvalidSignInRetryMax = 1,
+                CancelSignInCommands = ["-cancel"],
+                SignInCancelledMessage = "Sign in cancelled."
+            };
+
+            var sentActivities = new List<IActivity>();
+            var mockTokenClient = new Mock<IUserTokenClient>();
+
+            mockTokenClient
+                .Setup(c => c.GetTokenOrSignInResourceAsync(It.IsAny<string>(), It.IsAny<IActivity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenOrSignInResourceResponse
+                {
+                    SignInResource = new SignInResource
+                    {
+                        SignInLink = "https://login.test.com",
+                        TokenExchangeResource = new TokenExchangeResource { Id = "id", Uri = "uri" }
+                    }
+                });
+
+            var handler = new AzureBotUserAuthorization(HandlerName, _storage, _mockConnections.Object, settings);
+
+            var startContext = CreateTurnContext(ActivityTypes.Message, mockTokenClient.Object);
+            await handler.SignInUserAsync(startContext, forceSignIn: true, cancellationToken: CancellationToken.None);
+
+            var cancelActivity = CreateMessageActivity("test", "  -CANCEL  ");
+            var cancelContext = CreateTurnContextWithCapture(cancelActivity, mockTokenClient.Object, sentActivities);
+
+            var ex = await Assert.ThrowsAsync<AuthException>(() =>
+                handler.SignInUserAsync(cancelContext, cancellationToken: CancellationToken.None));
+
+            Assert.Equal(AuthExceptionReason.UserCancelled, ex.Cause);
+            Assert.Contains(sentActivities.OfType<Activity>(), a => a.Text == settings.SignInCancelledMessage);
+
+            sentActivities.Clear();
+            var nextMessage = CreateTurnContextWithCapture(CreateMessageActivity("test", "hello"), mockTokenClient.Object, sentActivities);
+            var result = await handler.SignInUserAsync(nextMessage, forceSignIn: true, cancellationToken: CancellationToken.None);
+
+            Assert.Null(result);
+            Assert.Contains(sentActivities.OfType<Activity>(), a => a.Attachments?.Any(att => att.ContentType == OAuthCard.ContentType) == true);
+        }
+
         #endregion
 
         #region Helpers
@@ -1463,7 +1567,7 @@ namespace Microsoft.Agents.Builder.Tests
             return context;
         }
 
-        private static Activity CreateMessageActivity(string channelId = "test")
+        private static Activity CreateMessageActivity(string channelId = "test", string text = null)
         {
             return new Activity
             {
@@ -1471,7 +1575,8 @@ namespace Microsoft.Agents.Builder.Tests
                 From = new ChannelAccount { Id = "user1" },
                 Recipient = new ChannelAccount { Id = "bot" },
                 Conversation = new ConversationAccount { Id = "convo1" },
-                ChannelId = channelId
+                ChannelId = channelId,
+                Text = text
             };
         }
 

--- a/src/tests/Microsoft.Agents.Builder.Tests/AzureBotUserAuthorizationTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/AzureBotUserAuthorizationTests.cs
@@ -1295,9 +1295,9 @@ namespace Microsoft.Agents.Builder.Tests
             var startResult = await handler.SignInUserAsync(startContext, forceSignIn: true, cancellationToken: CancellationToken.None);
             Assert.Null(startResult);
 
-            // User sends text before Teams sends signin/tokenExchange.
+            // User sends a text message before the expected signin/tokenExchange arrives.
             sentActivities.Clear();
-            var textDuringFlow = CreateMessageActivity();
+            var textDuringFlow = CreateMessageActivity(text: "hello?");
             var textContext = CreateTurnContextWithCapture(textDuringFlow, mockTokenClient.Object, sentActivities);
 
             // Act & Assert
@@ -1344,9 +1344,9 @@ namespace Microsoft.Agents.Builder.Tests
             var startResult = await handler.SignInUserAsync(startContext, forceSignIn: true, cancellationToken: CancellationToken.None);
             Assert.Null(startResult);
 
-            // User sends text before Teams sends signin/tokenExchange.
+            // User sends a text message before Teams sends signin/tokenExchange.
             sentActivities.Clear();
-            var textDuringFlow = CreateMessageActivity(Channels.Msteams);
+            var textDuringFlow = CreateMessageActivity(Channels.Msteams, "Hello?");
             
             var textContext = CreateTurnContextWithCapture(textDuringFlow, mockTokenClient.Object, sentActivities);
 

--- a/src/tests/Microsoft.Agents.Builder.Tests/AzureBotUserAuthorizationTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/AzureBotUserAuthorizationTests.cs
@@ -1258,6 +1258,117 @@ namespace Microsoft.Agents.Builder.Tests
             Assert.Equal((int)HttpStatusCode.OK, ((InvokeResponse)secondResponse.Value).Status);
         }
 
+        [Fact]
+        public async Task SignInUserAsync_ThrowsAuthException_WhenTextMessageDuringFlow()
+        {
+            // Arrange - Teams may deliver a user message before the expected signin invoke arrives.
+            var settings = new OAuthSettings
+            {
+                AzureBotOAuthConnectionName = ConnectionName,
+                Timeout = 900000,
+                InvalidSignInRetryMax = 1,
+            };
+
+            var sentActivities = new List<IActivity>();
+            var mockTokenClient = new Mock<IUserTokenClient>();
+            var finalToken = new TokenResponse { Token = "token", Expiration = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(30) };
+
+            mockTokenClient
+                .Setup(c => c.GetTokenOrSignInResourceAsync(It.IsAny<string>(), It.IsAny<IActivity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenOrSignInResourceResponse
+                {
+                    SignInResource = new SignInResource
+                    {
+                        SignInLink = "https://login.test.com",
+                        TokenExchangeResource = new TokenExchangeResource { Id = "id", Uri = "uri" }
+                    }
+                });
+
+            mockTokenClient
+                .Setup(c => c.ExchangeTokenAsync(It.IsAny<string>(), ConnectionName, It.IsAny<ChannelId>(), It.IsAny<TokenExchangeRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(finalToken);
+
+            var handler = new AzureBotUserAuthorization(HandlerName, _storage, _mockConnections.Object, settings);
+
+            // Start the flow.
+            var startContext = CreateTurnContext(ActivityTypes.Message, mockTokenClient.Object);
+            var startResult = await handler.SignInUserAsync(startContext, forceSignIn: true, cancellationToken: CancellationToken.None);
+            Assert.Null(startResult);
+
+            // User sends text before Teams sends signin/tokenExchange.
+            sentActivities.Clear();
+            var textDuringFlow = CreateMessageActivity();
+            var textContext = CreateTurnContextWithCapture(textDuringFlow, mockTokenClient.Object, sentActivities);
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<AuthException>(() =>
+                handler.SignInUserAsync(textContext, forceSignIn: false, cancellationToken: CancellationToken.None));
+            Assert.Equal(AuthExceptionReason.InvalidSignIn, ex.Cause);
+        }
+
+        [Fact]
+        public async Task TeamsSSO_TextMessageDuringFlow_SendsInProgressMessage_AndDoesNotConsumeRetry()
+        {
+            // Arrange - Teams may deliver a user message before the expected signin invoke arrives.
+            var settings = new OAuthSettings
+            {
+                AzureBotOAuthConnectionName = ConnectionName,
+                Timeout = 900000,
+                InvalidSignInRetryMax = 1,
+                TeamsSignInInProgressMessage = "Please finish signing and wait for completion"
+            };
+
+            var sentActivities = new List<IActivity>();
+            var mockTokenClient = new Mock<IUserTokenClient>();
+            var finalToken = new TokenResponse { Token = "teams-sso-token", Expiration = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(30) };
+
+            mockTokenClient
+                .Setup(c => c.GetTokenOrSignInResourceAsync(It.IsAny<string>(), It.IsAny<IActivity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenOrSignInResourceResponse
+                {
+                    SignInResource = new SignInResource
+                    {
+                        SignInLink = "https://login.test.com",
+                        TokenExchangeResource = new TokenExchangeResource { Id = "id", Uri = "uri" }
+                    }
+                });
+
+            mockTokenClient
+                .Setup(c => c.ExchangeTokenAsync(It.IsAny<string>(), ConnectionName, It.IsAny<ChannelId>(), It.IsAny<TokenExchangeRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(finalToken);
+
+            var handler = new AzureBotUserAuthorization(HandlerName, _storage, _mockConnections.Object, settings);
+
+            // Start the flow.
+            var startContext = CreateTeamsMessageTurnContext(mockTokenClient.Object);
+            var startResult = await handler.SignInUserAsync(startContext, forceSignIn: true, cancellationToken: CancellationToken.None);
+            Assert.Null(startResult);
+
+            // User sends text before Teams sends signin/tokenExchange.
+            sentActivities.Clear();
+            var textDuringFlow = CreateMessageActivity(Channels.Msteams);
+            
+            var textContext = CreateTurnContextWithCapture(textDuringFlow, mockTokenClient.Object, sentActivities);
+
+            var pendingResult = await handler.SignInUserAsync(textContext, cancellationToken: CancellationToken.None);
+
+            // Assert - flow remains pending and user gets a Teams-specific in-progress message.
+            Assert.Null(pendingResult);
+            var inProgressMessage = sentActivities.OfType<Activity>().LastOrDefault(a => a.Type == ActivityTypes.Message);
+            Assert.NotNull(inProgressMessage);
+            Assert.Equal(settings.TeamsSignInInProgressMessage, inProgressMessage.Text);
+
+            // The delayed signin/tokenExchange should still succeed even though retry max is 1.
+            sentActivities.Clear();
+            var tokenExchangeActivity = CreateTokenExchangeInvokeActivity("teams-sso-jwt");
+            var tokenExchangeContext = CreateTurnContextWithCapture(tokenExchangeActivity, mockTokenClient.Object, sentActivities);
+
+            var finalResult = await handler.SignInUserAsync(tokenExchangeContext, cancellationToken: CancellationToken.None);
+
+            Assert.NotNull(finalResult);
+            Assert.Equal("teams-sso-token", finalResult.Token);
+        }
+
         #endregion
 
         #region Helpers


### PR DESCRIPTION
Fixes # 853

## Description
This pull request enhances the Teams sign-in flow by adding support for user-initiated cancellation, improved messaging during authentication, and more robust handling of user messages during the sign-in process. It introduces new configuration options, refines the logic for handling user input, and significantly expands test coverage to ensure correct behavior for various scenarios.

**Sign-in flow enhancements:**

* Added support for user-initiated cancellation of the sign-in flow via configurable commands (e.g., `-cancel`, `/cancel`). When a cancellation command is detected, the flow state is reset, a configurable cancellation message is sent to the user, and an `AuthException` is thrown with a specific reason. [[1]](diffhunk://#diff-e10e7b360009c409937f224c65f67a377b0d41aa2354039db585b5be3980e39cR206-R217) [[2]](diffhunk://#diff-e10e7b360009c409937f224c65f67a377b0d41aa2354039db585b5be3980e39cR259-R284) [[3]](diffhunk://#diff-e10e7b360009c409937f224c65f67a377b0d41aa2354039db585b5be3980e39cR302-R309) [[4]](diffhunk://#diff-4c016d30a699b607ea29b0e304a41cd09201cfe61257d774bd9fe91987747337R39-R41)
* Improved handling of user messages during the sign-in flow, especially in Teams. If a user sends a message before completing sign-in, the bot now sends a configurable "sign-in in progress" message instead of consuming a retry attempt. [[1]](diffhunk://#diff-e10e7b360009c409937f224c65f67a377b0d41aa2354039db585b5be3980e39cL223-R239) [[2]](diffhunk://#diff-4c016d30a699b607ea29b0e304a41cd09201cfe61257d774bd9fe91987747337R39-R41)

**Configuration improvements:**

* Extended `OAuthSettings` with new properties: `TeamsSignInInProgressMessage`, `CancelSignInCommands`, and `SignInCancelledMessage`, all of which are configurable and have sensible defaults.

**Test coverage:**

* Added comprehensive tests to cover:
  - User message during sign-in flow triggers appropriate exception or in-progress message.
  - Cancellation commands (case-insensitive, configurable) reset the flow and send the correct message.
  - Flow state is properly cleared after cancellation, allowing new sign-ins to start cleanly.
* Improved test helpers to allow specifying message text for simulated user activities.

## Testing
These images show the sign-in in progress message and the cancel option in both WebChat and MSTeams channels.
<img width="2076" height="1622" alt="image" src="https://github.com/user-attachments/assets/eac3e757-736b-4eb0-b87f-c185364192b5" />
